### PR TITLE
Fix(readme): Use correct name for EventDrake

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Attribution is not required but appreciated. This helps us keep our data up to d
 - The majority of data is imported from [FanCons.com](https://fancons.com) and is annotated as such. Usage restrictions may apply.
 - Your convention may be able to be automatically imported. Automatic import is supported (to varying degrees) for the following registration systems:
   - [ConCat](https://concat.app)
-  - [FurDU](https://furdu.com.au) (including Aurawra, FurcoNZ)
+  - [EventDrake](https://eventdrake.net) (including Aurawra, FurCoNZ, FurDU)
   - [RAMS](https://reg.furfest.org) (Midwest FurFest only)
 - If you would like data.cons.fyi to automatically import your convention, please [file an issue](https://github.com/consfyi/data/issues/new?template=add-convention.yml) for convention listing. Please provide details on how event dates and venue information can be imported from your registration system, or if you are already using one of the supported registration systems.
 


### PR DESCRIPTION
These cons use EventDrake, developed by FurcoNZ. It's currently a closed beta, with each convention running a slightly different version.

If you need more info, feel free to reach out to either myself (I help administer Aurawra's instance), or someone on the EventDrake team (They are all really nice - I'm sure they'd be able to help yall).