### PR TITLE
Fix duplicate further-confusion-2026 event id breaking deploy

### DIFF
--- a/further-confusion.json
+++ b/further-confusion.json
@@ -19,20 +19,6 @@
       "id": "further-confusion-2026",
       "name": "Further Confusion 2026",
       "url": "https://furtherconfusion.org",
-      "startDate": "2027-01-14",
-      "endDate": "2027-01-18",
-      "venue": "San Jose Convention Center",
-      "address": "150 W San Carlos St, San Jose, CA 95113, USA",
-      "locale": "en-US",
-      "latLng": [
-        37.3291639,
-        -121.889011
-      ]
-    },
-    {
-      "id": "further-confusion-2026",
-      "name": "Further Confusion 2026",
-      "url": "https://furtherconfusion.org",
       "startDate": "2026-01-15",
       "endDate": "2026-01-19",
       "venue": "San Jose Convention Center",


### PR DESCRIPTION
## Problem
The `deploy` workflow has been failing on every run with:

```
ERROR:root:further-confusion/further-confusion-2026:$.id:not unique across all series, last seen in further-confusion
```

`further-confusion.json` contained **two** events with id `further-confusion-2026`. One was a stray copy that carried the **2027** dates (`2027-01-14`–`2027-01-18`) rather than the 2026 dates — it looks like it was duplicated from the `further-confusion-2027` entry directly above it and the id edited but the dates left untouched.

`tools/materialize.py` enforces globally-unique event ids across all series and `sys.exit(1)`s on a collision, so the site was never being published.

## Fix
Remove the malformed duplicate. The correct 2026 entry (`2026-01-15`–`2026-01-19`) remains.

## Verification
Ran `./tools/materialize.py "$OUT"` locally → **exit 0**; `further-confusion-{2023..2027}.json` all materialize cleanly and no duplicate event ids remain across any series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)