### PR TITLE
Activate import_concat fixes: bump submodule + wire rate-limit key

### DIFF
--- a/.github/workflows/import_concat.yml
+++ b/.github/workflows/import_concat.yml
@@ -22,6 +22,7 @@ jobs:
       - run: ./tools/data-importers/import_concat_all.sh
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          CONCAT_RATELIMIT_KEY: ${{ secrets.CONCAT_RATELIMIT_KEY }}
       - run: |
           git add .
           git diff-index --quiet HEAD || git commit -m "via import_concat"


### PR DESCRIPTION
Brings `consfyi/data` up to date with the merged `data-importers` work and wires the ConCat rate-limit key, so the `import_concat` job stops failing on furlingame.

**Contains:**
1. **Submodule bump** for `tools/data-importers` — picks up the resilient import scripts (consfyi/data-importers#1, merged) and the rate-limit-key support (consfyi/data-importers#2).
2. **Workflow wiring** — `import_concat.yml` now passes `CONCAT_RATELIMIT_KEY: ${{ secrets.CONCAT_RATELIMIT_KEY }}` into the importer. The secret is already set on this repo (encrypted; not a plaintext variable).

**⚠️ Before merging:** the submodule pointer here still targets `866278a` (resilience only). It must be re-pointed to `data-importers` `main` **after consfyi/data-importers#2 merges**, so the importer version that actually reads `CONCAT_RATELIMIT_KEY` is included. Until then the key is passed but unused.

Once both are in, furlingame's `/api/config` is fetched with the `x-ratelimit-key` header and the 403s stop; the key never leaks (host-scoped, request-only, never logged).