### PR TITLE
Housekeeping: Node 24 action bump + silence whenever deprecation in materialize

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           mkdir "$RUNNER_TEMP/out" &&
           ./tools/materialize.py "$RUNNER_TEMP/out" &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v8
       - run: |
           mkdir "$RUNNER_TEMP/out" &&
           ./tools/materialize.py "$RUNNER_TEMP/out" &&

--- a/.github/workflows/import_concat.yml
+++ b/.github/workflows/import_concat.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_concat.yml
+++ b/.github/workflows/import_concat.yml
@@ -12,10 +12,10 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_eventdrake.yml
+++ b/.github/workflows/import_eventdrake.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_eventdrake.yml
+++ b/.github/workflows/import_eventdrake.yml
@@ -12,10 +12,10 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_fancons.yml
+++ b/.github/workflows/import_fancons.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_fancons.yml
+++ b/.github/workflows/import_fancons.yml
@@ -12,10 +12,10 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_rams.yml
+++ b/.github/workflows/import_rams.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/.github/workflows/import_rams.yml
+++ b/.github/workflows/import_rams.yml
@@ -12,10 +12,10 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"

--- a/tools/materialize.py
+++ b/tools/materialize.py
@@ -218,7 +218,7 @@ def main():
 
     def pred(event):
         end_time = (
-            whenever.Date.parse_common_iso(event["endDate"])
+            whenever.Date.parse_iso(event["endDate"])
             .add(days=1)
             .at(whenever.Time(12, 0))
             .assume_tz(event.get("timezone", "UTC"))
@@ -228,8 +228,8 @@ def main():
     current = sorted(
         (event for event in events.values() if pred(event)),
         key=lambda event: (
-            whenever.Date.parse_common_iso(event["startDate"]),
-            whenever.Date.parse_common_iso(event["endDate"]),
+            whenever.Date.parse_iso(event["startDate"]),
+            whenever.Date.parse_iso(event["endDate"]),
             event["id"],
         ),
     )
@@ -246,12 +246,12 @@ def main():
         write_line("X-WR-CALNAME:cons.fyi")
         for event in current:
             start_date = (
-                whenever.Date.parse_common_iso(event["startDate"])
+                whenever.Date.parse_iso(event["startDate"])
                 .py_date()
                 .strftime("%Y%m%d")
             )
             end_date = (
-                whenever.Date.parse_common_iso(event["endDate"])
+                whenever.Date.parse_iso(event["endDate"])
                 .add(days=1)
                 .py_date()
                 .strftime("%Y%m%d")
@@ -288,8 +288,8 @@ def main():
             if event is not None
         ),
         key=lambda event: (
-            whenever.Date.parse_common_iso(event["startDate"]),
-            whenever.Date.parse_common_iso(event["endDate"]),
+            whenever.Date.parse_iso(event["startDate"]),
+            whenever.Date.parse_iso(event["endDate"]),
             event["id"],
         ),
     )


### PR DESCRIPTION
Two low-risk maintenance fixes.

## 1. Node 20 → Node 24 actions (deadline 2026-06-02)
The workflows warn that `actions/checkout@v4` and `astral-sh/setup-uv@v6` run on Node 20, and GitHub forces Actions onto Node 24 starting June 2nd, 2026. Bumped across all 5 workflows:
- `actions/checkout@v4` → `@v5` (Node 24)
- `astral-sh/setup-uv@v6` → `@v7` (Node 24)

`setup-uv` has no moving `v8` major tag (only `v8.x.y`), so `@v7` is the latest moving major tag that runs on Node 24 — verified in a fork run (a first attempt with `@v8` failed to resolve, which is how this was caught). The pages actions (`upload-pages-artifact`/`deploy-pages`) weren't flagged as Node-20 and are left untouched.

## 2. Silence the `whenever` deprecation warning in `materialize.py`
`materialize.py.lock` pins `whenever 0.9.2`, which deprecated `parse_common_iso()` for `parse_iso()` — the warning spam in deploy logs. Switched the 7 call sites to `parse_iso()`. Safe: `0.9.2` provides both names and newer `whenever` (`0.10`+) only has `parse_iso`, so it's forward-compatible. Verified `materialize.py` runs clean (exit 0, no warnings).

> Scope note: the importers stay on `parse_common_iso` — their locks pin `whenever 0.8.8` (no `parse_iso`), so they're correct as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)