### PR TITLE
Swap import_eventdrake workflow for import_furrynz

### DIFF
--- a/.github/workflows/import_furrynz.yml
+++ b/.github/workflows/import_furrynz.yml
@@ -1,4 +1,4 @@
-name: import_eventdrake
+name: import_furrynz
 on:
   schedule:
     - cron: "15 */6 * * *"
@@ -12,17 +12,15 @@ jobs:
   import:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: |
           git config --global user.name "cons.fyi GitHub bot"
           git config --global user.email "github@cons.fyi"
-      - run: ./tools/data-importers/import_eventdrake_all.sh
-        env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      - run: ./tools/data-importers/import_furrynz_all.sh
       - run: |
           git add .
-          git diff-index --quiet HEAD || git commit -m "via import_eventdrake"
+          git diff-index --quiet HEAD || git commit -m "via import_furrynz"
           git push


### PR DESCRIPTION
Companion to consfyi/data-importers#3.

Adds the `import_furrynz` scheduled workflow and removes `import_eventdrake.yml`, since all of EventDrake's cons now import from furry.nz. No secrets needed — furry.nz is public. Uses the Node-24 action versions (`checkout@v5`, `setup-uv@v7`).

**Validated end-to-end in a fork:** the workflow runs green and `import_furrynz` committed the furry.nz-sourced dates (including correcting FurDU 2025 and aurawra 2025 to match the hub).

## ⚠️ Merge order
1. Merge **consfyi/data-importers#3** (adds `import_furrynz.py` + `import_furrynz_all.sh`, removes `import_eventdrake_all.sh`).
2. Bump this repo's `tools/data-importers` submodule to that merge commit (I'll re-point it).
3. Then this PR — once the submodule contains `import_furrynz_all.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)