### PR TITLE
Fix Furski 2026 dates and venue

### DIFF
--- a/furski.json
+++ b/furski.json
@@ -5,14 +5,14 @@
       "id": "furski-2026",
       "name": "Furski 2026",
       "url": "https://fur.ski",
-      "startDate": "2026-01-01",
-      "endDate": "2026-12-31",
-      "venue": "Devil's Head Resort",
-      "address": "S6330 Bluff Rd, Merrimac, WI 53561, United States",
+      "startDate": "2026-03-14",
+      "endDate": "2026-03-14",
+      "venue": "Nordic Mountain",
+      "address": "W5806 County Road W, Mount Morris, WI 54984, United States",
       "locale": "en-US",
       "latLng": [
-        43.4180036,
-        -89.6268972
+        44.1203196,
+        -89.1819797
       ]
     },
     {


### PR DESCRIPTION
Closes #12.

The `furski-2026` entry had **placeholder dates** (`2026-01-01 → 2026-12-31`) and the previous **Devil's Head Resort** venue. Both are now corrected:

- **Single day, `2026-03-14`** ("PI Day").
- **Venue: Nordic Mountain**, W5806 County Road W, Mount Morris, WI 54984 → `[44.1203196, -89.1819797]` (OSM).

**Source:** fur.ski's official Bluesky post — *"Furski 2026 - Video Games Edition / Nordic Mountain in Mt. Morris, WI / 3-14-2026 - PI Day"* (https://bsky.app/profile/fur.ski/post/3mdzyjvugzc24).

Validated: `./tools/materialize.py` accepts it, timezone resolves to `America/Chicago`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)