### PR TITLE
Pass CONCAT_PROXY settings to the import_concat job

### DIFF
--- a/.github/workflows/import_concat.yml
+++ b/.github/workflows/import_concat.yml
@@ -23,6 +23,9 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           CONCAT_RATELIMIT_KEY: ${{ secrets.CONCAT_RATELIMIT_KEY }}
+          CONCAT_PROXY: ${{ secrets.CONCAT_PROXY }}
+          CONCAT_PROXY_SECRET: ${{ secrets.CONCAT_PROXY_SECRET }}
+          CONCAT_PROXY_HOSTS: ${{ secrets.CONCAT_PROXY_HOSTS }}
       - run: |
           git add .
           git diff-index --quiet HEAD || git commit -m "via import_concat"


### PR DESCRIPTION
Companion to consfyi/data-importers#4 (Worker proxy for furlingame).

Adds `CONCAT_PROXY` / `CONCAT_PROXY_SECRET` / `CONCAT_PROXY_HOSTS` (repo secrets) to the `import_concat` job env so the importer can route blocked hosts (furlingame) through the Cloudflare Worker. Other cons are unaffected; if the secrets are unset the importer behaves exactly as today.

## To activate (after data-importers#4 merges)
1. Deploy the Worker (see `tools/data-importers/proxy/README.md`) on the consfyi Cloudflare account.
2. Set repo secrets: `CONCAT_PROXY` (Worker URL), `CONCAT_PROXY_SECRET`, `CONCAT_PROXY_HOSTS=reg.furlingame.com`.
3. Bump the `tools/data-importers` submodule to include data-importers#4 (the importer version that reads `CONCAT_PROXY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)