### PR TITLE
Add PAWAI 2026

### DIFF
--- a/pawai.json
+++ b/pawai.json
@@ -1,0 +1,19 @@
+{
+  "name": "PAWAI",
+  "events": [
+    {
+      "id": "pawai-2026",
+      "name": "PAWAI 2026",
+      "url": "https://pawai.id",
+      "startDate": "2026-10-03",
+      "endDate": "2026-10-04",
+      "venue": "Grand Istana Rama Hotel",
+      "address": "Jalan Pantai Kuta, Kuta, Badung, Bali, Indonesia",
+      "locale": "id-ID",
+      "latLng": [
+        -8.7152656,
+        115.1690945
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #24.

New series for **PAWAI** (Indonesian furry con, Kuta, Bali), requested by the organizer.

- **Dates `2026-10-03 → 2026-10-04`** — confirmed on pawai.id (*"Gods Paradise 3rd & 4th October 2026"*).
- **Venue** Grand Istana Rama Hotel, `Jalan Pantai Kuta, Kuta, Badung, Bali` → `[-8.7152656, 115.1690945]` (OSM).
- **locale `id-ID`** (matches the existing Indonesian con).

Validated: `./tools/materialize.py` accepts it, timezone `Asia/Makassar`.