### PR TITLE
Add Camp Feral! 2026

### DIFF
--- a/camp-feral.json
+++ b/camp-feral.json
@@ -2,6 +2,20 @@
   "name": "Camp Feral!",
   "events": [
     {
+      "id": "camp-feral-2026",
+      "name": "Camp Feral! 2026",
+      "url": "https://campferal.org",
+      "startDate": "2026-08-20",
+      "endDate": "2026-08-24",
+      "venue": "Camp Arowhon",
+      "address": "1 Arowhon Road, Algonquin Park, ON P0A 1H0, Canada",
+      "locale": "en-CA",
+      "latLng": [
+        45.596578,
+        -78.73186799999999
+      ]
+    },
+    {
       "id": "camp-feral-2025",
       "name": "Camp Feral! 2025",
       "url": "https://campferal.org",


### PR DESCRIPTION
Adds **Camp Feral! 2026** to `camp-feral.json`.

| field | value |
|---|---|
| dates | 2026-08-20 to 2026-08-24 |
| venue | Camp Arowhon, Algonquin Park, ON |
| source | [campferal.org](https://campferal.org) |

Requested on Bluesky ([ianmcgecko post](https://bsky.app/profile/ianmcgecko.bsky.social/post/3mkuzwqc6v22k) pointing at @campferal.bsky.social) and signed off by tolf. Dates verified against the official site; venue/address/latLng reused from the existing 2025 entry (same annual location).