### PR TITLE
Add Bluesky accounts (DID + handle) to cons

### DIFF
--- a/aberacon.json
+++ b/aberacon.json
@@ -1,5 +1,9 @@
 {
   "name": "Aberacon",
+  "bluesky": {
+    "did": "did:plc:fxqamrjizs6dhp7vwgskble5",
+    "handle": "skydreampegasus.bsky.social"
+  },
   "events": [
     {
       "id": "aberacon-2026",

--- a/adelaide-anthros.json
+++ b/adelaide-anthros.json
@@ -1,5 +1,9 @@
 {
   "name": "Adelaide Anthros",
+  "bluesky": {
+    "did": "did:plc:k7b7jvmdtr5jycic6v3baehk",
+    "handle": "adlanthros.bsky.social"
+  },
   "events": [
     {
       "id": "adelaide-anthros-2026",

--- a/ainmhicon.json
+++ b/ainmhicon.json
@@ -1,5 +1,9 @@
 {
   "name": "Ainmhícon",
+  "bluesky": {
+    "did": "did:plc:cmx6qbpzi24s4ulllxjmqkfm",
+    "handle": "ainmhicon.ie"
+  },
   "events": [
     {
       "id": "ainmhicon-2026",

--- a/alamo-city-furry-invasion.json
+++ b/alamo-city-furry-invasion.json
@@ -1,5 +1,9 @@
 {
   "name": "Alamo City Furry Invasion",
+  "bluesky": {
+    "did": "did:plc:i54z3b7sl4jladt3k56ttsoa",
+    "handle": "furryinvasion.bsky.social"
+  },
   "events": [
     {
       "id": "alamo-city-furry-invasion-2026",

--- a/anthro-irish.json
+++ b/anthro-irish.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro Irish",
+  "bluesky": {
+    "did": "did:plc:lftq3seuhfjgojkpauk2ob5o",
+    "handle": "anthro.irish"
+  },
   "events": [
     {
       "id": "anthro-irish-2026",

--- a/anthro-new-england.json
+++ b/anthro-new-england.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro New England",
+  "bluesky": {
+    "did": "did:plc:srxungr7qhhxzllfsdfltzau",
+    "handle": "ane.boston"
+  },
   "events": [
     {
       "id": "anthro-new-england-2027",

--- a/anthro-new-mexico.json
+++ b/anthro-new-mexico.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro New Mexico",
+  "bluesky": {
+    "did": "did:plc:qazt7llgx2jecskuv7iuip7p",
+    "handle": "anthronewmexico.bsky.social"
+  },
   "events": [
     {
       "id": "anthro-new-mexico-2026",

--- a/anthro-northwest.json
+++ b/anthro-northwest.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro Northwest",
+  "bluesky": {
+    "did": "did:plc:ngj2ak6kaqa2yzmbnlzlqlbq",
+    "handle": "anthronorthwest.bsky.social"
+  },
   "events": [
     {
       "id": "anthro-northwest-8",

--- a/anthro-socal.json
+++ b/anthro-socal.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro SoCal",
+  "bluesky": {
+    "did": "did:plc:qihcil4vll52xqadxriiqrxm",
+    "handle": "anthrosocal.org"
+  },
   "events": [
     {
       "id": "anthro-socal-2026",

--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthro Weekend Utah",
+  "bluesky": {
+    "did": "did:plc:gbnuncvqp6sjt5pmlqd4no5s",
+    "handle": "anthroweekendutah.org"
+  },
   "events": [
     {
       "id": "anthro-weekend-utah-2026",

--- a/anthrocon.json
+++ b/anthrocon.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthrocon",
+  "bluesky": {
+    "did": "did:plc:ulwyvthzao6goq6pqth2j5z3",
+    "handle": "anthrocon.org"
+  },
   "events": [
     {
       "id": "anthrocon-2026",

--- a/anthroexpo.json
+++ b/anthroexpo.json
@@ -1,5 +1,9 @@
 {
   "name": "AnthroExpo",
+  "bluesky": {
+    "did": "did:plc:2yyx6fpki4ibgkmljp6yjtnw",
+    "handle": "anthroexpo.com"
+  },
   "events": [
     {
       "id": "anthroexpo-2027",

--- a/anthrohio.json
+++ b/anthrohio.json
@@ -1,5 +1,9 @@
 {
   "name": "AnthrOhio",
+  "bluesky": {
+    "did": "did:plc:ahefwarth4puxhaykgkxxfms",
+    "handle": "anthrohio.org"
+  },
   "events": [
     {
       "id": "anthrohio-2026",

--- a/anthros-and-alpine.json
+++ b/anthros-and-alpine.json
@@ -1,5 +1,9 @@
 {
   "name": "Anthros & Alpine",
+  "bluesky": {
+    "did": "did:plc:fugd4ne5q2sqqpjtvlw3pa7h",
+    "handle": "anthroalpine.bsky.social"
+  },
   "events": [
     {
       "id": "anthros-and-alpine-2026",

--- a/anthrotales.json
+++ b/anthrotales.json
@@ -1,5 +1,9 @@
 {
   "name": "AnthroTales",
+  "bluesky": {
+    "did": "did:plc:exarj7ai7pz3s7t7o2tdbmh3",
+    "handle": "anthrotales.eu"
+  },
   "events": [
     {
       "id": "anthrotales-1",

--- a/aquatifur.json
+++ b/aquatifur.json
@@ -1,5 +1,9 @@
 {
   "name": "AquatiFur",
+  "bluesky": {
+    "did": "did:plc:efgqcoutfj3rxzkeihyaz26q",
+    "handle": "aquatifur.com"
+  },
   "events": [
     {
       "id": "aquatifur-2026",

--- a/argentina-furfiesta.json
+++ b/argentina-furfiesta.json
@@ -1,5 +1,9 @@
 {
   "name": "Argentina FurFiesta",
+  "bluesky": {
+    "did": "did:plc:j4rggbvlmmp32xkish3tazdc",
+    "handle": "furfiesta.bsky.social"
+  },
   "events": [
     {
       "id": "argentina-furfiesta-2026",

--- a/aurawra.json
+++ b/aurawra.json
@@ -1,5 +1,9 @@
 {
   "name": "Aurawra",
+  "bluesky": {
+    "did": "did:plc:6yotpovggygkohgkpiqhqr7g",
+    "handle": "aurawra.org"
+  },
   "events": [
     {
       "id": "aurawra-2026",

--- a/awoostria.json
+++ b/awoostria.json
@@ -1,5 +1,9 @@
 {
   "name": "Awoostria",
+  "bluesky": {
+    "did": "did:plc:iszkvg44gkgt5pf2cxxfqu2x",
+    "handle": "awoostria.at"
+  },
   "events": [
     {
       "id": "awoostria-2026",

--- a/babyfur-con.json
+++ b/babyfur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Babyfur Con",
+  "bluesky": {
+    "did": "did:plc:t6rv55gfndnu5w3b5zlnhefg",
+    "handle": "babyfurcon.com"
+  },
   "events": [
     {
       "id": "babyfur-con-2025",

--- a/barkada-furfest.json
+++ b/barkada-furfest.json
@@ -1,5 +1,9 @@
 {
   "name": "Barkada Furfest",
+  "bluesky": {
+    "did": "did:plc:zi25qxibb6en44uipzomtzkq",
+    "handle": "barkadafurfest.bsky.social"
+  },
   "events": [
     {
       "id": "barkada-furfest-2026",

--- a/bavarian-furdance.json
+++ b/bavarian-furdance.json
@@ -1,5 +1,9 @@
 {
   "name": "Bavarian Furdance",
+  "bluesky": {
+    "did": "did:plc:okl4a5gmga3eqi2mtecvmydj",
+    "handle": "bayern-furs.de"
+  },
   "events": [
     {
       "id": "bavarian-furdance-17",

--- a/bewhiskered.json
+++ b/bewhiskered.json
@@ -1,5 +1,9 @@
 {
   "name": "Bewhiskered",
+  "bluesky": {
+    "did": "did:plc:ofijpde6vmpgf5ckztc3iiro",
+    "handle": "bewhiskeredcon.org"
+  },
   "events": [
     {
       "id": "bewhiskered-2026",

--- a/big-sky-camp-paw.json
+++ b/big-sky-camp-paw.json
@@ -1,5 +1,9 @@
 {
   "name": "Big Sky Camp Paw",
+  "bluesky": {
+    "did": "did:plc:ptlvs5qz3bfg374ocsbtsemp",
+    "handle": "camppaw.org"
+  },
   "events": [
     {
       "id": "big-sky-camp-paw-2026",

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Biggest Little Fur Con",
+  "bluesky": {
+    "did": "did:plc:zkvyhzkfhmrlb5xgthda35fm",
+    "handle": "goblfc.org"
+  },
   "events": [
     {
       "id": "biggest-little-fur-con-2026",

--- a/brasil-furfest.json
+++ b/brasil-furfest.json
@@ -1,5 +1,9 @@
 {
   "name": "Brasil FurFest",
+  "bluesky": {
+    "did": "did:plc:hpoo54twc5v7volse2a2jbpy",
+    "handle": "brasilfurfest.bsky.social"
+  },
   "events": [
     {
       "id": "brasil-furfest-2026",

--- a/calfurry.json
+++ b/calfurry.json
@@ -1,5 +1,9 @@
 {
   "name": "Calfurry",
+  "bluesky": {
+    "did": "did:plc:jimdwyslsqmqwqsa7oxujv75",
+    "handle": "calfurry.ca"
+  },
   "events": [
     {
       "id": "calfurry-2026",

--- a/camp-feral.json
+++ b/camp-feral.json
@@ -1,5 +1,9 @@
 {
   "name": "Camp Feral!",
+  "bluesky": {
+    "did": "did:plc:dlkl3ar4r5ee2spc4zywtw2r",
+    "handle": "campferal.bsky.social"
+  },
   "events": [
     {
       "id": "camp-feral-2026",

--- a/camp-mani-toebeans.json
+++ b/camp-mani-toebeans.json
@@ -1,5 +1,9 @@
 {
   "name": "Camp Mani-Toebeans",
+  "bluesky": {
+    "did": "did:plc:et4hnrcwodrqe5nu42qxg5ua",
+    "handle": "campmani-toebeans.bsky.social"
+  },
   "events": [
     {
       "id": "camp-mani-toebeans-2026",

--- a/canfurence.json
+++ b/canfurence.json
@@ -1,5 +1,9 @@
 {
   "name": "CanFURence",
+  "bluesky": {
+    "did": "did:plc:msevw3cpwqtlrhfrffrragcn",
+    "handle": "canfurence.bsky.social"
+  },
   "events": [
     {
       "id": "canfurence-2026",

--- a/canthrofur.json
+++ b/canthrofur.json
@@ -1,5 +1,9 @@
 {
   "name": "CanthroFur",
+  "bluesky": {
+    "did": "did:plc:xdrmsbjlyxqcup36stm4oxbz",
+    "handle": "canthrofur.org"
+  },
   "events": [
     {
       "id": "canthrofur-2026",

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Capital Fur Con",
+  "bluesky": {
+    "did": "did:plc:tcogiehhws3chyw7jvqnozda",
+    "handle": "capitalfurcon.org"
+  },
   "events": [
     {
       "id": "capital-fur-con-2027",

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -1,5 +1,9 @@
 {
   "name": "Carolina Furfare",
+  "bluesky": {
+    "did": "did:plc:eamjvw2tcnvapbkjhbwyuiy7",
+    "handle": "carolinafurfare.bsky.social"
+  },
   "events": [
     {
       "id": "carolina-furfare-2026",

--- a/confuror.json
+++ b/confuror.json
@@ -1,5 +1,9 @@
 {
   "name": "Confuror",
+  "bluesky": {
+    "did": "did:plc:sj3gp6suyjokm32gk7swrfcd",
+    "handle": "confuror.bsky.social"
+  },
   "events": [
     {
       "id": "confuror-2026",

--- a/confuzzled.json
+++ b/confuzzled.json
@@ -1,5 +1,9 @@
 {
   "name": "ConFuzzled",
+  "bluesky": {
+    "did": "did:plc:vkij4nukia5yta6xjaep6esl",
+    "handle": "confuzzled.org.uk"
+  },
   "events": [
     {
       "id": "confuzzled-2026",

--- a/core-element.json
+++ b/core-element.json
@@ -1,5 +1,9 @@
 {
   "name": "Core Element",
+  "bluesky": {
+    "did": "did:plc:3m6rr24rkxrf4gl54chz6wjw",
+    "handle": "coreelement.bsky.social"
+  },
   "events": [
     {
       "id": "core-element-2026",

--- a/denfur.json
+++ b/denfur.json
@@ -1,5 +1,9 @@
 {
   "name": "DenFur",
+  "bluesky": {
+    "did": "did:plc:5qadfstdsv7yd2nvezahdlxq",
+    "handle": "denfur.org"
+  },
   "events": [
     {
       "id": "denfur-2026",

--- a/dutch-furcon.json
+++ b/dutch-furcon.json
@@ -1,5 +1,9 @@
 {
   "name": "Dutch Furcon",
+  "bluesky": {
+    "did": "did:plc:fwbafkszmspqcsx37xpcodzy",
+    "handle": "dutchfurcon.com"
+  },
   "events": [
     {
       "id": "dutch-furcon-11",

--- a/east.json
+++ b/east.json
@@ -1,5 +1,9 @@
 {
   "name": "East",
+  "bluesky": {
+    "did": "did:plc:g24kqlngojrjbo35hdcxvkym",
+    "handle": "sachsenfurs.de"
+  },
   "events": [
     {
       "id": "east-14",

--- a/eufuria.json
+++ b/eufuria.json
@@ -1,5 +1,9 @@
 {
   "name": "Eufuria",
+  "bluesky": {
+    "did": "did:plc:hnrit3a6bvynnpaqq37pc7qq",
+    "handle": "eufuria.org"
+  },
   "events": [
     {
       "id": "eufuria-2026",

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -1,5 +1,9 @@
 {
   "name": "Eurofurence",
+  "bluesky": {
+    "did": "did:plc:uneztaz2bvfqtzyyopyzi3em",
+    "handle": "eurofurence.org"
+  },
   "events": [
     {
       "id": "eurofurence-30",

--- a/fauntastic.json
+++ b/fauntastic.json
@@ -1,5 +1,9 @@
 {
   "name": "Fauntastic",
+  "bluesky": {
+    "did": "did:plc:65vovribkeitvpyznzygh3yl",
+    "handle": "fauntastic.eu"
+  },
   "events": [
     {
       "id": "fauntastic-2026",

--- a/fetchnw-frostbite-weekend.json
+++ b/fetchnw-frostbite-weekend.json
@@ -1,5 +1,9 @@
 {
   "name": "FetchNW Frostbite Weekend",
+  "bluesky": {
+    "did": "did:plc:n64xnsl5jwwffy2swsrn62ka",
+    "handle": "fetchnw.com"
+  },
   "events": [
     {
       "id": "fetchnw-frostbite-weekend-2025",

--- a/fluufff.json
+++ b/fluufff.json
@@ -1,5 +1,9 @@
 {
   "name": "Flüüfff",
+  "bluesky": {
+    "did": "did:plc:fei6suxorko4znzdnjl3wrik",
+    "handle": "fluufffcon.bsky.social"
+  },
   "events": [
     {
       "id": "fluufff-2026",

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -1,5 +1,9 @@
 {
   "name": "Fur-Eh!",
+  "bluesky": {
+    "did": "did:plc:xekssaocuarinic2wxunlmnm",
+    "handle": "fur-eh.bsky.social"
+  },
   "events": [
     {
       "id": "fur-eh-2026",

--- a/fur-the-more.json
+++ b/fur-the-more.json
@@ -1,5 +1,9 @@
 {
   "name": "Fur the 'More",
+  "bluesky": {
+    "did": "did:plc:ex4dpm3lgpjwjuhvfpbw3duq",
+    "handle": "furthemore.org"
+  },
   "events": [
     {
       "id": "fur-the-more-2026",

--- a/furality-online-xperience.json
+++ b/furality-online-xperience.json
@@ -1,5 +1,9 @@
 {
   "name": "Furality Online Xperience",
+  "bluesky": {
+    "did": "did:plc:o7d3ydmb5h5qve7db5ret76k",
+    "handle": "furality.org"
+  },
   "events": [
     {
       "id": "furality-online-xperience-2026",

--- a/furban.json
+++ b/furban.json
@@ -1,5 +1,9 @@
 {
   "name": "Furban",
+  "bluesky": {
+    "did": "did:plc:tdhu2asm72omizpmxsn2ulf3",
+    "handle": "furbanjungle.bsky.social"
+  },
   "events": [
     {
       "id": "furban-2027",

--- a/furcamp-michigan.json
+++ b/furcamp-michigan.json
@@ -1,5 +1,9 @@
 {
   "name": "FurCamp Michigan",
+  "bluesky": {
+    "did": "did:plc:h34yzo4tktldpnwha2wyq7zi",
+    "handle": "furcampmi.bsky.social"
+  },
   "events": [
     {
       "id": "furcamp-michigan-2026",

--- a/furcamp.json
+++ b/furcamp.json
@@ -1,5 +1,9 @@
 {
   "name": "Furcamp",
+  "bluesky": {
+    "did": "did:plc:ruw3kwkjtrttdbvgzdlxsrcy",
+    "handle": "furcamp.com"
+  },
   "events": [
     {
       "id": "furcamp-2026",

--- a/furcation.json
+++ b/furcation.json
@@ -1,5 +1,9 @@
 {
   "name": "Furcation",
+  "bluesky": {
+    "did": "did:plc:clgiak22ikoxswjcxn6prgw7",
+    "handle": "furcationland.org"
+  },
   "events": [
     {
       "id": "furcation-2024",

--- a/furcationland.json
+++ b/furcationland.json
@@ -1,5 +1,9 @@
 {
   "name": "Furcationland",
+  "bluesky": {
+    "did": "did:plc:clgiak22ikoxswjcxn6prgw7",
+    "handle": "furcationland.org"
+  },
   "events": [
     {
       "id": "furcationland-2026",

--- a/furciety.json
+++ b/furciety.json
@@ -1,5 +1,9 @@
 {
   "name": "Furciety",
+  "bluesky": {
+    "did": "did:plc:675rbmaa6k2eehkjgcpkz6vg",
+    "handle": "furciety.de"
+  },
   "events": [
     {
       "id": "furciety-2026",

--- a/furconz-camp.json
+++ b/furconz-camp.json
@@ -1,5 +1,9 @@
 {
   "name": "FurcoNZ Camp",
+  "bluesky": {
+    "did": "did:plc:vyqtxhbuv4b3cskbfoygeyt7",
+    "handle": "furconz.bsky.social"
+  },
   "events": [
     {
       "id": "furconz-camp-2025",

--- a/furconz-hotel.json
+++ b/furconz-hotel.json
@@ -1,5 +1,9 @@
 {
   "name": "FurcoNZ Hotel",
+  "bluesky": {
+    "did": "did:plc:vyqtxhbuv4b3cskbfoygeyt7",
+    "handle": "furconz.bsky.social"
+  },
   "events": [
     {
       "id": "furconz-hotel-2025",

--- a/fureast.json
+++ b/fureast.json
@@ -1,5 +1,9 @@
 {
   "name": "FurEast",
+  "bluesky": {
+    "did": "did:plc:5dtasfyeqhg7xj257ss3focq",
+    "handle": "fureast.fr"
+  },
   "events": [
     {
       "id": "fureast-2026",

--- a/furever-west.json
+++ b/furever-west.json
@@ -1,5 +1,9 @@
 {
   "name": "Furever West",
+  "bluesky": {
+    "did": "did:plc:bng4keu7y2wp3qjunienycee",
+    "handle": "fureverwest.bsky.social"
+  },
   "events": [
     {
       "id": "furever-west-2026",

--- a/furgeddaboutit.json
+++ b/furgeddaboutit.json
@@ -1,5 +1,9 @@
 {
   "name": "Furgeddaboutit",
+  "bluesky": {
+    "did": "did:plc:jjrjjs24paafnoncv2gg3dvv",
+    "handle": "furgeddaboutit.org"
+  },
   "events": [
     {
       "id": "furgeddaboutit-2026",

--- a/furgether.json
+++ b/furgether.json
@@ -1,5 +1,9 @@
 {
   "name": "Furgether",
+  "bluesky": {
+    "did": "did:plc:jdnmvui6m3sovuxvwy746ngn",
+    "handle": "furgether.at"
+  },
   "events": [
     {
       "id": "furgether-2025",

--- a/furlandia.json
+++ b/furlandia.json
@@ -1,5 +1,9 @@
 {
   "name": "Furlandia",
+  "bluesky": {
+    "did": "did:plc:bb4y6p2pei7clwmarkwoyddt",
+    "handle": "furlandia.bsky.social"
+  },
   "events": [
     {
       "id": "furlandia-2026",

--- a/furlingame.json
+++ b/furlingame.json
@@ -1,5 +1,9 @@
 {
   "name": "Furlingame",
+  "bluesky": {
+    "did": "did:plc:bwf4zux2gax2kkmplggshyxd",
+    "handle": "furlingame.com"
+  },
   "events": [
     {
       "id": "furlingame-2027",

--- a/furnal-equinox.json
+++ b/furnal-equinox.json
@@ -1,5 +1,9 @@
 {
   "name": "Furnal Equinox",
+  "bluesky": {
+    "did": "did:plc:g7b4ncbjtguyen43rp2434w5",
+    "handle": "furnalequinox.com"
+  },
   "events": [
     {
       "id": "furnal-equinox-2026",

--- a/furnavia.json
+++ b/furnavia.json
@@ -1,5 +1,9 @@
 {
   "name": "Furnavia",
+  "bluesky": {
+    "did": "did:plc:a7yrdfbzvv4h3h4jdpviljkh",
+    "handle": "furnavia.bsky.social"
+  },
   "events": [
     {
       "id": "furnavia-2026",

--- a/furpile.json
+++ b/furpile.json
@@ -1,5 +1,9 @@
 {
   "name": "Furpile",
+  "bluesky": {
+    "did": "did:plc:komzyrz73m3jtc5duweds46j",
+    "handle": "furpile.pl"
+  },
   "events": [
     {
       "id": "furpile-2025",

--- a/furpocalypse.json
+++ b/furpocalypse.json
@@ -1,5 +1,9 @@
 {
   "name": "Furpocalypse",
+  "bluesky": {
+    "did": "did:plc:azcrwj7meawnegprye7h3j2e",
+    "handle": "furpocalypse.org"
+  },
   "events": [
     {
       "id": "furpocalypse-2026",

--- a/furrest-city.json
+++ b/furrest-city.json
@@ -1,5 +1,9 @@
 {
   "name": "Furrest City",
+  "bluesky": {
+    "did": "did:plc:gs3oxjmihf65m2efx2xu75rr",
+    "handle": "furrestcity.org"
+  },
   "events": [
     {
       "id": "furrest-city-2026",

--- a/furry-blacklight.json
+++ b/furry-blacklight.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry BlackLight",
+  "bluesky": {
+    "did": "did:plc:s42vpi52gnwxbwvsafcnmcf5",
+    "handle": "fblacklight.bsky.social"
+  },
   "events": [
     {
       "id": "furry-blacklight-2026",

--- a/furry-down-under.json
+++ b/furry-down-under.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry Down Under",
+  "bluesky": {
+    "did": "did:plc:cit3srdvvirtppe6a3ouaom5",
+    "handle": "furdu.com.au"
+  },
   "events": [
     {
       "id": "furry-down-under-2026",

--- a/furry-migration.json
+++ b/furry-migration.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry Migration",
+  "bluesky": {
+    "did": "did:plc:ittzfj5vrjmgupumwkws36dv",
+    "handle": "furrymigration.org"
+  },
   "events": [
     {
       "id": "furry-migration-2026",

--- a/furry-retreat.json
+++ b/furry-retreat.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry Retreat",
+  "bluesky": {
+    "did": "did:plc:vo6lbuicgrpbcvpanpm2b7ep",
+    "handle": "wkndfurryretreat.bsky.social"
+  },
   "events": [
     {
       "id": "furry-retreat-2026",

--- a/furry-ski-weekend.json
+++ b/furry-ski-weekend.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry Ski Weekend",
+  "bluesky": {
+    "did": "did:plc:yjg2qdan6xds2knrjkv645dm",
+    "handle": "furryskiweekend.com"
+  },
   "events": [
     {
       "id": "furry-ski-weekend-2026",

--- a/furry-weekend-atlanta.json
+++ b/furry-weekend-atlanta.json
@@ -1,5 +1,9 @@
 {
   "name": "Furry Weekend Atlanta",
+  "bluesky": {
+    "did": "did:plc:7ekpvrg7ne2oltxiiag4zcvo",
+    "handle": "furryweekend.com"
+  },
   "events": [
     {
       "id": "furry-weekend-atlanta-2027",

--- a/furrydelphia.json
+++ b/furrydelphia.json
@@ -1,5 +1,9 @@
 {
   "name": "Furrydelphia",
+  "bluesky": {
+    "did": "did:plc:te6ft4boi7vrmg6g7r5z4nx6",
+    "handle": "furrydelphia.org"
+  },
   "events": [
     {
       "id": "furrydelphia-2026",

--- a/furski.json
+++ b/furski.json
@@ -1,5 +1,9 @@
 {
   "name": "Furski",
+  "bluesky": {
+    "did": "did:plc:v35sycvmrnj7uu6wnhi3z3vj",
+    "handle": "techno.fur.ski"
+  },
   "events": [
     {
       "id": "furski-2026",

--- a/fursonacon.json
+++ b/fursonacon.json
@@ -1,5 +1,9 @@
 {
   "name": "FursonaCon",
+  "bluesky": {
+    "did": "did:plc:wjfjlofatfjrk34zrldmpwua",
+    "handle": "fursonacon.bsky.social"
+  },
   "events": [
     {
       "id": "fursonacon-2026",

--- a/fursquared.json
+++ b/fursquared.json
@@ -1,5 +1,9 @@
 {
   "name": "FurSquared",
+  "bluesky": {
+    "did": "did:plc:2s3t7hs6j3uqosgcgbueegac",
+    "handle": "fursquared.com"
+  },
   "events": [
     {
       "id": "fursquared-2027",

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -1,5 +1,9 @@
 {
   "name": "Further Confusion",
+  "bluesky": {
+    "did": "did:plc:fj45oznjbvlgoyzjqi6tlt3n",
+    "handle": "furcon.bsky.social"
+  },
   "events": [
     {
       "id": "further-confusion-2027",

--- a/furvana.json
+++ b/furvana.json
@@ -1,5 +1,9 @@
 {
   "name": "Furvana",
+  "bluesky": {
+    "did": "did:plc:sdbhssde3hgqdezn4duufvhc",
+    "handle": "furvana.bsky.social"
+  },
   "events": [
     {
       "id": "furvana-2025",

--- a/furvaria.json
+++ b/furvaria.json
@@ -1,5 +1,9 @@
 {
   "name": "Furvaria",
+  "bluesky": {
+    "did": "did:plc:cy7rinhd32hdtthwwqa2lasq",
+    "handle": "furvaria.de"
+  },
   "events": [
     {
       "id": "furvaria-2026",

--- a/furvester.json
+++ b/furvester.json
@@ -1,5 +1,9 @@
 {
   "name": "Furvester",
+  "bluesky": {
+    "did": "did:plc:c7h3662ycf6ysztaz6hnyqc4",
+    "handle": "furvester.org"
+  },
   "events": [
     {
       "id": "furvester-7",

--- a/furway.json
+++ b/furway.json
@@ -1,5 +1,9 @@
 {
   "name": "Furway",
+  "bluesky": {
+    "did": "did:plc:z5hagjlrpfa7czgbkrmbjm5g",
+    "handle": "furway.no"
+  },
   "events": [
     {
       "id": "furway-2026",

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -1,5 +1,9 @@
 {
   "name": "Futrołajki",
+  "bluesky": {
+    "did": "did:plc:oy67eitzxchghmwagnebvp56",
+    "handle": "futrolajki.pl"
+  },
   "events": [
     {
       "id": "futrolajki-2026",

--- a/galactic-camp.json
+++ b/galactic-camp.json
@@ -1,5 +1,9 @@
 {
   "name": "Galactic Camp",
+  "bluesky": {
+    "did": "did:plc:jikwl2zbi5ch4kkt4kquff6e",
+    "handle": "galacticcamp.bsky.social"
+  },
   "events": [
     {
       "id": "galactic-camp-2026",

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -1,5 +1,9 @@
 {
   "name": "Gateway FurMeet",
+  "bluesky": {
+    "did": "did:plc:fvapco74poz7okj4apntezkj",
+    "handle": "gatewayfurmeet.org"
+  },
   "events": [
     {
       "id": "gateway-furmeet-2026",

--- a/gdakon.json
+++ b/gdakon.json
@@ -1,5 +1,9 @@
 {
   "name": "Gdakon",
+  "bluesky": {
+    "did": "did:plc:rcszz3ima2ijf4vepnxjzdev",
+    "handle": "gdakon.bsky.social"
+  },
   "events": [
     {
       "id": "gdakon-2026",

--- a/genderverse-furcon.json
+++ b/genderverse-furcon.json
@@ -1,5 +1,9 @@
 {
   "name": "Genderverse FurCon",
+  "bluesky": {
+    "did": "did:plc:ft5iujk7bkezl6ypfqack3oj",
+    "handle": "genderversefurcon.com"
+  },
   "events": [
     {
       "id": "genderverse-furcon-2025",

--- a/get-out-the-float.json
+++ b/get-out-the-float.json
@@ -1,5 +1,9 @@
 {
   "name": "Get Out The Float",
+  "bluesky": {
+    "did": "did:plc:dudgclqiibaulmlueqbehe2r",
+    "handle": "getoutthefloat.com"
+  },
   "events": [
     {
       "id": "get-out-the-float-2026",

--- a/golden-leaves-con.json
+++ b/golden-leaves-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Golden Leaves Con",
+  "bluesky": {
+    "did": "did:plc:v6ixvbshj7esjom2ds32ojk2",
+    "handle": "furry.ch"
+  },
   "events": [
     {
       "id": "golden-leaves-con-16",

--- a/goldenhorn.json
+++ b/goldenhorn.json
@@ -1,5 +1,9 @@
 {
   "name": "GoldenHorn",
+  "bluesky": {
+    "did": "did:plc:fegcyzgp3utqoyqsqrwuyg3c",
+    "handle": "goldenhorn.si"
+  },
   "events": [
     {
       "id": "goldenhorn-2026",

--- a/heartland-howloween.json
+++ b/heartland-howloween.json
@@ -1,5 +1,9 @@
 {
   "name": "Heartland Howloween",
+  "bluesky": {
+    "did": "did:plc:mtchwur7zw7mnusl7vuyi76f",
+    "handle": "heartlandhowloween.bsky.social"
+  },
   "events": [
     {
       "id": "heartland-howloween-2026",

--- a/howlcon.json
+++ b/howlcon.json
@@ -1,5 +1,9 @@
 {
   "name": "HowlCon",
+  "bluesky": {
+    "did": "did:plc:mkozxx3fopzclh5rcp7x7wj5",
+    "handle": "howlcore.bsky.social"
+  },
   "events": [
     {
       "id": "howlcon-2026",

--- a/howloween.json
+++ b/howloween.json
@@ -1,5 +1,9 @@
 {
   "name": "Howloween",
+  "bluesky": {
+    "did": "did:plc:dnpromglesu6p3ok3czfygkp",
+    "handle": "howloween.ca"
+  },
   "events": [
     {
       "id": "howloween-2025",

--- a/ibercon.json
+++ b/ibercon.json
@@ -1,5 +1,9 @@
 {
   "name": "Ibercon",
+  "bluesky": {
+    "did": "did:plc:nfmk4uewhcudqpslperqowci",
+    "handle": "ibercon.org"
+  },
   "events": [
     {
       "id": "ibercon-2026",

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -1,5 +1,9 @@
 {
   "name": "Indonesia Weekend Anthro Gathering",
+  "bluesky": {
+    "did": "did:plc:xufabiyszlj5ygfxwbpkfsah",
+    "handle": "iwag.furries.id"
+  },
   "events": [
     {
       "id": "indonesia-weekend-anthro-gathering-2026",

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -1,5 +1,9 @@
 {
   "name": "IndyFurCon",
+  "bluesky": {
+    "did": "did:plc:n27hl3siwx4um3j3tbf5aegw",
+    "handle": "indyfurcon.org"
+  },
   "events": [
     {
       "id": "indyfurcon-2026",

--- a/infurnity.json
+++ b/infurnity.json
@@ -1,5 +1,9 @@
 {
   "name": "Infurnity",
+  "bluesky": {
+    "did": "did:plc:uiqsmywrawljvwhmia6odqcs",
+    "handle": "infurnity.bsky.social"
+  },
   "events": [
     {
       "id": "infurnity-2026",

--- a/lakeside-furs.json
+++ b/lakeside-furs.json
@@ -1,5 +1,9 @@
 {
   "name": "Lakeside Furs",
+  "bluesky": {
+    "did": "did:plc:moekp22hjcanfcgi234w2rem",
+    "handle": "lakesidefurs.at"
+  },
   "events": [
     {
       "id": "lakeside-furs-2026",

--- a/las-vegas-fur-con.json
+++ b/las-vegas-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Las Vegas Fur Con",
+  "bluesky": {
+    "did": "did:plc:flpymgjkbta3zvshvn4253zu",
+    "handle": "lasvegasfurcon.org"
+  },
   "events": [
     {
       "id": "las-vegas-fur-con-2027",

--- a/les-furfurieux.json
+++ b/les-furfurieux.json
@@ -1,5 +1,9 @@
 {
   "name": "Les Furfurieux",
+  "bluesky": {
+    "did": "did:plc:36psugzwy3rwjdyiddfxnmdg",
+    "handle": "furfurieux.bsky.social"
+  },
   "events": [
     {
       "id": "les-furfurieux-2026",

--- a/little-island-furcon.json
+++ b/little-island-furcon.json
@@ -1,5 +1,9 @@
 {
   "name": "Little Island Furcon",
+  "bluesky": {
+    "did": "did:plc:j6l7vrkdhydbbkfnz3fhhknj",
+    "handle": "littleislandfur.com"
+  },
   "events": [
     {
       "id": "little-island-furcon-2026",

--- a/lone-star-fur-con.json
+++ b/lone-star-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Lone Star Fur Con",
+  "bluesky": {
+    "did": "did:plc:tir2n7nxfddqnf7vlp7qekp2",
+    "handle": "lonestarfurcon.bsky.social"
+  },
   "events": [
     {
       "id": "lone-star-fur-con-2026",

--- a/melbourne-fur-con.json
+++ b/melbourne-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Melbourne Fur Con",
+  "bluesky": {
+    "did": "did:plc:ucoapegqexcd7a73cfpz7nhg",
+    "handle": "melbfurcon.com"
+  },
   "events": [
     {
       "id": "melbourne-fur-con-2026",

--- a/melbourne-furry-convention.json
+++ b/melbourne-furry-convention.json
@@ -1,5 +1,9 @@
 {
   "name": "Melbourne Furry Convention",
+  "bluesky": {
+    "did": "did:plc:ucoapegqexcd7a73cfpz7nhg",
+    "handle": "melbfurcon.com"
+  },
   "events": [
     {
       "id": "melbourne-furry-convention-2026",

--- a/mephit-fur-meet.json
+++ b/mephit-fur-meet.json
@@ -1,5 +1,9 @@
 {
   "name": "Mephit Fur Meet",
+  "bluesky": {
+    "did": "did:plc:7kjnfrrppp6omzjl7n7vlwpj",
+    "handle": "mephitfurmeet.org"
+  },
   "events": [
     {
       "id": "mephit-fur-meet-2026",

--- a/mephit-mini-con.json
+++ b/mephit-mini-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Mephit Mini Con",
+  "bluesky": {
+    "did": "did:plc:fvfl3n7t757jbbmbpmzwclhs",
+    "handle": "mephitminicon.bsky.social"
+  },
   "events": [
     {
       "id": "mephit-mini-con-26",

--- a/midwest-furfest.json
+++ b/midwest-furfest.json
@@ -1,5 +1,9 @@
 {
   "name": "Midwest FurFest",
+  "bluesky": {
+    "did": "did:plc:uwoi7anxjcden4hkzck6h6c7",
+    "handle": "furfest.org"
+  },
   "events": [
     {
       "id": "midwest-furfest-2026",

--- a/mischief-district.json
+++ b/mischief-district.json
@@ -1,5 +1,9 @@
 {
   "name": "Mischief District",
+  "bluesky": {
+    "did": "did:plc:n2heu2u77jmbu6b3q7xa46xg",
+    "handle": "magpieevents.org"
+  },
   "events": [
     {
       "id": "mischief-district-2025",

--- a/motor-city-furry-con.json
+++ b/motor-city-furry-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Motor City Furry Con",
+  "bluesky": {
+    "did": "did:plc:j3au6jfmpgjzu76dps4sdwqa",
+    "handle": "motorcityfurrycon.org"
+  },
   "events": [
     {
       "id": "motor-city-furry-con-2026",

--- a/nashum-furcon.json
+++ b/nashum-furcon.json
@@ -1,5 +1,9 @@
 {
   "name": "Nashum FurCon",
+  "bluesky": {
+    "did": "did:plc:vjnfnhefq62e74ps2yfcfcly",
+    "handle": "nashumfurcon.org"
+  },
   "events": [
     {
       "id": "nashum-furcon-2026",

--- a/new-years-furry-ball.json
+++ b/new-years-furry-ball.json
@@ -1,5 +1,9 @@
 {
   "name": "New Years Furry Ball",
+  "bluesky": {
+    "did": "did:plc:ha7l7zxbpoqmo7iifjyizdg4",
+    "handle": "newyearsfurryball.bsky.social"
+  },
   "events": [
     {
       "id": "new-years-furry-ball-2026",

--- a/noctfurnal.json
+++ b/noctfurnal.json
@@ -1,5 +1,9 @@
 {
   "name": "Noctfurnal",
+  "bluesky": {
+    "did": "did:plc:3qnwehdxbsnpfuvx6huu2l5t",
+    "handle": "noctfurnalevents.bsky.social"
+  },
   "events": [
     {
       "id": "noctfurnal-2026",

--- a/nordicfuzzcon.json
+++ b/nordicfuzzcon.json
@@ -1,5 +1,9 @@
 {
   "name": "NordicFuzzCon",
+  "bluesky": {
+    "did": "did:plc:i7jct5sy4z2tb2q7gritvhjc",
+    "handle": "nordicfuzzcon.org"
+  },
   "events": [
     {
       "id": "nordicfuzzcon-2027",

--- a/orli-forsztival.json
+++ b/orli-forsztival.json
@@ -1,5 +1,9 @@
 {
   "name": "Örli Försztivál",
+  "bluesky": {
+    "did": "did:plc:yljqiafx2ljh2d46byhevwp2",
+    "handle": "orliforsztival.bsky.social"
+  },
   "events": [
     {
       "id": "orli-forsztival-2025",

--- a/palmetto-fur-the-season.json
+++ b/palmetto-fur-the-season.json
@@ -1,5 +1,9 @@
 {
   "name": "Palmetto Fur The Season",
+  "bluesky": {
+    "did": "did:plc:gtltrd7u36kzsa7cutk2iatq",
+    "handle": "palmettofurtheseason.org"
+  },
   "events": [
     {
       "id": "palmetto-fur-the-season-1",

--- a/pawai.json
+++ b/pawai.json
@@ -1,5 +1,9 @@
 {
   "name": "PAWAI",
+  "bluesky": {
+    "did": "did:plc:6ucns3rhpfo2nzlarn2tlnjx",
+    "handle": "pawaiid.bsky.social"
+  },
   "events": [
     {
       "id": "pawai-2026",

--- a/pawcon.json
+++ b/pawcon.json
@@ -1,5 +1,9 @@
 {
   "name": "PAWCon",
+  "bluesky": {
+    "did": "did:plc:jg56dnxiqwj6m64n3numfbv3",
+    "handle": "pawcon.bsky.social"
+  },
   "events": [
     {
       "id": "pawcon-2026",

--- a/pawsome.json
+++ b/pawsome.json
@@ -1,5 +1,9 @@
 {
   "name": "Pawsome",
+  "bluesky": {
+    "did": "did:plc:6qeufewqi72im3pho5u3lud2",
+    "handle": "pawsome.bsky.social"
+  },
   "events": [
     {
       "id": "pawsome-2026",

--- a/pawstral.json
+++ b/pawstral.json
@@ -1,5 +1,9 @@
 {
   "name": "Pawstral",
+  "bluesky": {
+    "did": "did:plc:fmowwvretbveqlmejk4sxfl5",
+    "handle": "pawstral.bsky.social"
+  },
   "events": [
     {
       "id": "pawstral-2025",

--- a/pragfur-outing.json
+++ b/pragfur-outing.json
@@ -1,5 +1,9 @@
 {
   "name": "PragFUR Outing",
+  "bluesky": {
+    "did": "did:plc:cw7azrpuoijtu6fgzd43io3e",
+    "handle": "pragfur.cz"
+  },
   "events": [
     {
       "id": "pragfur-outing-2025",

--- a/purple-clouds-festival.json
+++ b/purple-clouds-festival.json
@@ -1,5 +1,9 @@
 {
   "name": "Purple Clouds Festival",
+  "bluesky": {
+    "did": "did:plc:xj4h7gjqq6xrxryybx22dvkx",
+    "handle": "purple-clouds.de"
+  },
   "events": [
     {
       "id": "purple-clouds-festival-2026",

--- a/reffurence.json
+++ b/reffurence.json
@@ -1,5 +1,9 @@
 {
   "name": "Reffurence",
+  "bluesky": {
+    "did": "did:plc:c3jyfxezu3uvjtx2rxlxa6cg",
+    "handle": "reffurence.bsky.social"
+  },
   "events": [
     {
       "id": "reffurence-2025",

--- a/sachsen-fur-dance.json
+++ b/sachsen-fur-dance.json
@@ -1,5 +1,9 @@
 {
   "name": "Sachsen Fur Dance",
+  "bluesky": {
+    "did": "did:plc:g24kqlngojrjbo35hdcxvkym",
+    "handle": "sachsenfurs.de"
+  },
   "events": [
     {
       "id": "sachsen-fur-dance-28",

--- a/scotiacon.json
+++ b/scotiacon.json
@@ -1,5 +1,9 @@
 {
   "name": "Scotiacon",
+  "bluesky": {
+    "did": "did:plc:ykiko7fa24cbv2bmffeylfys",
+    "handle": "scotiacon.bsky.social"
+  },
   "events": [
     {
       "id": "scotiacon-2027",

--- a/slofluffcon.json
+++ b/slofluffcon.json
@@ -1,5 +1,9 @@
 {
   "name": "SloFluffCon",
+  "bluesky": {
+    "did": "did:plc:l2fj5sphxk3qhlu62dzehzqs",
+    "handle": "slofluffcon.bsky.social"
+  },
   "events": [
     {
       "id": "slofluffcon-2026",

--- a/spooktacufur.json
+++ b/spooktacufur.json
@@ -1,5 +1,9 @@
 {
   "name": "Spooktacufur",
+  "bluesky": {
+    "did": "did:plc:s3mvtnizy6nqfhutpeqaguao",
+    "handle": "spooktacufur.com"
+  },
   "events": [
     {
       "id": "spooktacufur-2026",

--- a/springfurcon.json
+++ b/springfurcon.json
@@ -1,5 +1,9 @@
 {
   "name": "SpringFurCon",
+  "bluesky": {
+    "did": "did:plc:trp43rflbbae5vmuh7g4j4kc",
+    "handle": "springfurcon.bsky.social"
+  },
   "events": [
     {
       "id": "springfurcon-2026",

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -1,5 +1,9 @@
 {
   "name": "StratosFur",
+  "bluesky": {
+    "did": "did:plc:a2gt2pfvvoovijq4uc2ivije",
+    "handle": "stratosfur.org"
+  },
   "events": [
     {
       "id": "stratosfur-2026",

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -1,5 +1,9 @@
 {
   "name": "Tails and Tornadoes Fur Con",
+  "bluesky": {
+    "did": "did:plc:dum5xzdrx7qkj3jtlrc3yaje",
+    "handle": "tailsandtornadoes.org"
+  },
   "events": [
     {
       "id": "tails-and-tornadoes-fur-con-2026",

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -1,5 +1,9 @@
 {
   "name": "Tails of Summer",
+  "bluesky": {
+    "did": "did:plc:dn7cq63ck4j5fgdhdn36qamz",
+    "handle": "tailsofsummer.com"
+  },
   "events": [
     {
       "id": "tails-of-summer-2026",

--- a/tails-of-terror.json
+++ b/tails-of-terror.json
@@ -1,5 +1,9 @@
 {
   "name": "Tails of Terror",
+  "bluesky": {
+    "did": "did:plc:cit3srdvvirtppe6a3ouaom5",
+    "handle": "furdu.com.au"
+  },
   "events": [
     {
       "id": "tails-of-terror-2026",

--- a/texas-furry-fiesta.json
+++ b/texas-furry-fiesta.json
@@ -1,5 +1,9 @@
 {
   "name": "Texas Furry Fiesta",
+  "bluesky": {
+    "did": "did:plc:oujlp4sqhvjgurciippmzqjd",
+    "handle": "djkrillik.bsky.social"
+  },
   "events": [
     {
       "id": "texas-furry-fiesta-2026",

--- a/texas-furry-siesta.json
+++ b/texas-furry-siesta.json
@@ -1,5 +1,9 @@
 {
   "name": "Texas Furry Siesta",
+  "bluesky": {
+    "did": "did:plc:kq37zqwjxnkpfpvt2r7upygu",
+    "handle": "furrysiesta.org"
+  },
   "events": [
     {
       "id": "texas-furry-siesta-2026",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -6,6 +6,21 @@
       "type": "string",
       "minLength": 1
     },
+    "bluesky": {
+      "type": "object",
+      "properties": {
+        "did": {
+          "type": "string",
+          "pattern": "^did:"
+        },
+        "handle": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["did"],
+      "additionalProperties": false
+    },
     "events": {
       "type": "array",
       "items": {

--- a/vancoufur.json
+++ b/vancoufur.json
@@ -1,5 +1,9 @@
 {
   "name": "VancouFur",
+  "bluesky": {
+    "did": "did:plc:5tccqxugf2h7pocamiydvsth",
+    "handle": "vancoufur.bsky.social"
+  },
   "events": [
     {
       "id": "vancoufur-2026",

--- a/volley-weekend.json
+++ b/volley-weekend.json
@@ -1,5 +1,9 @@
 {
   "name": "Volley Weekend",
+  "bluesky": {
+    "did": "did:plc:kjhbzkn22ss6o5o5tv6bmeon",
+    "handle": "volleyfurs.ch"
+  },
   "events": [
     {
       "id": "volley-weekend-3",

--- a/west-aussie-fur-frenzy.json
+++ b/west-aussie-fur-frenzy.json
@@ -1,5 +1,9 @@
 {
   "name": "West Aussie Fur Frenzy",
+  "bluesky": {
+    "did": "did:plc:67czct2gvdwtihvbtzzaqsfh",
+    "handle": "waff.net.au"
+  },
   "events": [
     {
       "id": "west-aussie-fur-frenzy-2025",

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -1,5 +1,9 @@
 {
   "name": "Western PA Furry Weekend",
+  "bluesky": {
+    "did": "did:plc:syftgxeqo6hbgi34cyigzkq3",
+    "handle": "wpafw.bsky.social"
+  },
   "events": [
     {
       "id": "western-pa-furry-weekend-2026",

--- a/wild-north.json
+++ b/wild-north.json
@@ -1,5 +1,9 @@
 {
   "name": "Wild North",
+  "bluesky": {
+    "did": "did:plc:ybayv2jmpdcpcl3ggid2jj55",
+    "handle": "wildnorth.bsky.social"
+  },
   "events": [
     {
       "id": "wild-north-2026",

--- a/woods-flock.json
+++ b/woods-flock.json
@@ -1,5 +1,9 @@
 {
   "name": "Woods Flock",
+  "bluesky": {
+    "did": "did:plc:2kubjovntsb3srk76t2dexjm",
+    "handle": "woodsflock.bsky.social"
+  },
   "events": [
     {
       "id": "woods-flock-2027",

--- a/yorkshire-furs-summer-party.json
+++ b/yorkshire-furs-summer-party.json
@@ -1,5 +1,9 @@
 {
   "name": "Yorkshire Furs Summer Party",
+  "bluesky": {
+    "did": "did:plc:pyv5xtpycnzuckhynqguxzx4",
+    "handle": "yorkshirefurs.org.uk"
+  },
   "events": [
     {
       "id": "yorkshire-furs-summer-party-2025",


### PR DESCRIPTION
Adds an optional top-level `bluesky` object to each con that has a **confirmed official Bluesky account** — 139 of 226 cons.

### Model
```json
{
  "name": "Anthrocon",
  "bluesky": { "did": "did:plc:…", "handle": "anthrocon.org" },
  "events": [ … ]
}
```
- **`did`** (required) is the stable canonical identifier — handles change, DIDs don't.
- **`handle`** is a human-readable cache for diffs/display; refreshable from the DID.
- The field is **omitted** for cons without a confirmed account (not null-filled), matching the existing optional-field convention. Schema (`tools/schema.json`) updated and `tools/format.py` applied.

### How the accounts were found
Multi-method, each account verified: name search on the AppView, domain-as-handle resolution, then website scraping (raw HTML + headless-Chrome JS render) of each con's own site for its linked Bluesky, cross-checked against the furryli.st directory. Every entry resolves to a live account and its DID was captured at write time.

### Coverage
The remaining ~87 cons are mostly non-English/regional events that don't appear to be on Bluesky (Weibo/QQ/Misskey/Telegram instead); those can be filled in manually later. This PR is purely additive — no existing fields change.