### PR TITLE
Materialize series bluesky onto events; add 'Add Bluesky account' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-bluesky.yml
+++ b/.github/ISSUE_TEMPLATE/add-bluesky.yml
@@ -1,0 +1,44 @@
+name: Add Bluesky account
+description: Tell us a convention's official Bluesky account
+title: "Add Bluesky account: [INSERT NAME HERE]"
+labels:
+  - bluesky
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Know the official Bluesky account for a convention we're missing it for? Let us know here.
+
+        The account must be the convention's own official account, verifiable from its website or other official sources.
+
+  - id: name
+    type: input
+    attributes:
+      label: Name
+      description: The name of the convention.
+      placeholder: e.g. My Cool Furry Con
+    validations:
+      required: true
+
+  - id: handle
+    type: input
+    attributes:
+      label: Bluesky account
+      description: The convention's Bluesky handle or profile link.
+      placeholder: e.g. @mycoolfurrycon.bsky.social or https://bsky.app/profile/mycoolfurrycon.bsky.social
+    validations:
+      required: true
+
+  - id: source
+    type: input
+    attributes:
+      label: Where is this linked?
+      description: A page that confirms this is the convention's official account (e.g. their website footer or links page).
+      placeholder: e.g. https://mycoolfurrycon.com
+
+  - id: comments
+    type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Anything else you'd like to add about your request.

--- a/tools/materialize.py
+++ b/tools/materialize.py
@@ -186,6 +186,8 @@ def main():
                 (lat, lng) = event["latLng"]
                 event["timezone"] = tzfpy.get_tz(lng, lat)
             event["seriesId"] = series_id
+            if "bluesky" in series:
+                event["bluesky"] = series["bluesky"]
 
             if previous_event is not None and "attendance" in previous_event:
                 event["previousAttendance"] = previous_event["attendance"]


### PR DESCRIPTION
## Summary
Make the con→Bluesky account mapping from #29 usable downstream, and give people a way to fill gaps.

- `tools/materialize.py` now copies a series-level `bluesky:{did,handle}` onto each materialized event, so consumers read it from `events/*.json` and `current.jsonl`. No-op for series without a `bluesky` field.
- New `.github/ISSUE_TEMPLATE/add-bluesky.yml` issue form to report a convention's official Bluesky account when we're missing it.

## Why
#29 (merged) added `bluesky` to the raw con files, but the web app reads the *materialized* event files, not the raw series files — without this propagation the field never reaches the frontend. This is the small enabling change for the web UI (consfyi/web PR).

## Notes
- Adds a new `bluesky` issue label — GitHub silently skips it if the label doesn't exist yet; create it for triage.
- Verified locally: ran `materialize.py` against main's data → 82/105 current events gained `bluesky` (e.g. `anthrocon-2026`).

## Test plan
`uv run tools/materialize.py <out>`, then confirm `out/events/<id>.json` + `out/current.jsonl` carry `bluesky` for mapped cons.
