### PR TITLE
Key dates: schema + rollout to 62 cons (Bluesky-extracted)

### DIFF
--- a/adelaide-anthros.json
+++ b/adelaide-anthros.json
@@ -17,7 +17,53 @@
       "latLng": [
         -34.9776336,
         138.5108833
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-05-09",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3mlfq3mxcs22u",
+            "asOf": "2026-05-09T07:32:14.940Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-09",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3mlf7tr2zbs27",
+            "asOf": "2026-05-09T02:41:30.950Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-06-01",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3mn7dyh4u4l2p",
+            "asOf": "2026-06-01T05:30:07.876Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-28",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3moub5catyq22",
+            "asOf": "2026-06-22T06:30:15.454Z",
+            "confidence": 0.95
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-06-21",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t",
+            "asOf": "2026-06-21T05:30:07.834Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-08-21",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t",
+            "asOf": "2026-06-21T05:30:07.834Z",
+            "confidence": 0.9
+          }
+        }
+      }
     }
   ]
 }

--- a/alamo-city-furry-invasion.json
+++ b/alamo-city-furry-invasion.json
@@ -17,7 +17,53 @@
       "latLng": [
         29.8391454,
         -97.9691577
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-10-12",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3m2zskkp7uc2t",
+            "asOf": "2025-10-12T23:01:20.467Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-04-01",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mih66nmsg22x",
+            "asOf": "2026-04-01T17:01:33.539Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-02-01",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mdsvyszkfc2o",
+            "asOf": "2026-02-01T18:01:06.660Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-02-18",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mdsvyszkfc2o",
+            "asOf": "2026-02-01T18:01:06.660Z",
+            "confidence": 0.95
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-04-06",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mitqjwomtc2y",
+            "asOf": "2026-04-06T17:01:56.353Z",
+            "confidence": 0.88
+          },
+          "closes": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mn3jnkakk224",
+            "asOf": "2026-05-30T17:00:45.745Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "alamo-city-furry-invasion-2025",

--- a/anthro-irish.json
+++ b/anthro-irish.json
@@ -17,7 +17,31 @@
       "latLng": [
         51.9013551,
         -8.4675944
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-10-01",
+            "source": "https://bsky.app/profile/anthro.irish/post/3m25pwcctl22i",
+            "asOf": "2025-10-01T18:59:40.436Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-07",
+            "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",
+            "asOf": "2026-05-07T18:06:59.029Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-04",
+            "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",
+            "asOf": "2026-05-07T18:06:59.029Z",
+            "confidence": 0.85
+          }
+        }
+      }
     }
   ]
 }

--- a/anthro-irish.json
+++ b/anthro-irish.json
@@ -21,10 +21,10 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2025-10-01",
-            "source": "https://bsky.app/profile/anthro.irish/post/3m25pwcctl22i",
-            "asOf": "2025-10-01T18:59:40.436Z",
-            "confidence": 0.9
+            "date": "2025-10-08",
+            "source": "https://bsky.app/profile/anthro.irish/post/3m2pd7bxpd22d",
+            "asOf": "2025-10-08T18:59:58.670Z",
+            "confidence": 0.95
           }
         },
         "panels": {

--- a/anthro-new-england.json
+++ b/anthro-new-england.json
@@ -17,7 +17,31 @@
       "latLng": [
         42.3459926,
         -71.0430104
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-08-01",
+            "source": "https://bsky.app/profile/ane.boston/post/3mpk2jbri3e2x",
+            "asOf": "2026-06-30T22:30:15.848Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/ane.boston/post/3mpk2jbri3e2x",
+            "asOf": "2026-06-30T22:30:15.848Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/ane.boston/post/3mplv7ed4u32g",
+            "asOf": "2026-07-01T16:00:33.727Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "anthro-new-england-2026",

--- a/anthro-new-mexico.json
+++ b/anthro-new-mexico.json
@@ -17,7 +17,33 @@
       "latLng": [
         35.0843859,
         -106.650422
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-11-06",
+            "source": "https://bsky.app/profile/anthronewmexico.bsky.social/post/3m4yg3emohc2f",
+            "asOf": "2025-11-06T20:35:49.400Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-06-16",
+            "source": "https://bsky.app/profile/anthronewmexico.bsky.social/post/3mofz7budwk2n",
+            "asOf": "2026-06-16T14:30:56.086Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-01-25",
+            "source": "https://bsky.app/profile/anthronewmexico.bsky.social/post/3mdavwis3es2i",
+            "asOf": "2026-01-25T14:11:53.542Z",
+            "confidence": 0.88
+          }
+        }
+      }
     }
   ]
 }

--- a/anthro-socal.json
+++ b/anthro-socal.json
@@ -17,7 +17,47 @@
       "latLng": [
         34.0655006,
         -117.6064432
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-04-01",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mig4zbtjgi2a",
+            "asOf": "2026-04-01T07:07:58.000Z",
+            "confidence": 0.95
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-30",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mmkc3dev4j2x",
+            "asOf": "2026-05-23T20:30:01.000Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-13",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mjfh2xmulb2c",
+            "asOf": "2026-04-13T18:00:24.000Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-05-04",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mjfh2xmulb2c",
+            "asOf": "2026-04-13T18:00:24.000Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-22",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3movedespfg2g",
+            "asOf": "2026-06-22T17:00:00.000Z",
+            "confidence": 0.92
+          }
+        }
+      }
     },
     {
       "id": "another-furry-con-2025",

--- a/anthro-socal.json
+++ b/anthro-socal.json
@@ -50,6 +50,12 @@
           }
         },
         "panels": {
+          "opens": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mkqdyzt2db2j",
+            "asOf": "2026-04-30T19:30:07.000Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-06-22",
             "source": "https://bsky.app/profile/anthrosocal.org/post/3movedespfg2g",

--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -17,7 +17,53 @@
       "latLng": [
         41.084896,
         -111.9810485
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-30",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mdm3z3v76k2s",
+            "asOf": "2026-01-31T01:00:34.207Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-22",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mlod5g2zj22o",
+            "asOf": "2026-05-12T17:34:33.836Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-04",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3ml2aomprm22o",
+            "asOf": "2026-05-04T17:57:15.240Z",
+            "confidence": 0.88
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-01-30",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mdm3z3v76k2s",
+            "asOf": "2026-01-31T01:00:34.207Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-02-13",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3me7lmr475k2a",
+            "asOf": "2026-02-06T19:00:01.188Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-01-30",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mdm3z3v76k2s",
+            "asOf": "2026-01-31T01:00:34.207Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "anthro-weekend-utah-2025",

--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -55,6 +55,20 @@
             "confidence": 0.9
           }
         },
+        "panels": {
+          "opens": {
+            "date": "2026-03-17",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t",
+            "asOf": "2026-03-17T02:05:44.665Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-04-17",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t",
+            "asOf": "2026-03-17T02:05:44.665Z",
+            "confidence": 0.95
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-01-30",

--- a/anthrocon.json
+++ b/anthrocon.json
@@ -34,6 +34,14 @@
             "asOf": "2026-02-20T02:23:21.466Z",
             "confidence": 0.9
           }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-23",
+            "source": "https://bsky.app/profile/anthrocon.org/post/3molfwwp2ak2d",
+            "asOf": "2026-06-18T18:02:13.282Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/anthrocon.json
+++ b/anthrocon.json
@@ -17,7 +17,25 @@
       "latLng": [
         40.4455472,
         -79.9962844
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-06-26",
+            "source": "https://bsky.app/profile/anthrocon.org/post/3mo44glg2dk23",
+            "asOf": "2026-06-12T16:02:04.818Z",
+            "confidence": 0.95
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-03-10",
+            "source": "https://bsky.app/profile/anthrocon.org/post/3mfb2hi3w7c2w",
+            "asOf": "2026-02-20T02:23:21.466Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "anthrocon-2025",

--- a/aquatifur.json
+++ b/aquatifur.json
@@ -17,7 +17,17 @@
       "latLng": [
         43.6652353,
         -89.7847062
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-11-28",
+            "source": "https://bsky.app/profile/aquatifur.com/post/3m6pixmjspm27",
+            "asOf": "2025-11-28T10:23:50-08:00",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "aquatifur-2025",

--- a/aurawra.json
+++ b/aurawra.json
@@ -17,7 +17,39 @@
       "latLng": [
         -33.8122314,
         151.0049991
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-05-04",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mkzcqak22m2l",
+            "asOf": "2026-05-04T09:01:14.810Z",
+            "confidence": 0.92
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2025-12-14",
+            "source": "https://bsky.app/profile/aurawra.org/post/3m7w6i4jflq2n",
+            "asOf": "2025-12-14T03:30:01.954Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-01-16",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mcjonuryy422",
+            "asOf": "2026-01-16T08:30:30.576Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-03-23",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mhpk3khagr2w",
+            "asOf": "2026-03-23T07:30:39.798Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "aurawra-2025",

--- a/aurawra.json
+++ b/aurawra.json
@@ -19,6 +19,14 @@
         151.0049991
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-05-29",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mmy77gp5gc23",
+            "asOf": "2026-05-29T09:15:54.891Z",
+            "confidence": 0.95
+          }
+        },
         "hotel": {
           "opens": {
             "date": "2026-05-04",
@@ -39,6 +47,14 @@
             "source": "https://bsky.app/profile/aurawra.org/post/3mcjonuryy422",
             "asOf": "2026-01-16T08:30:30.576Z",
             "confidence": 0.9
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
+            "asOf": "2026-06-04T05:49:59.850Z",
+            "confidence": 0.95
           }
         },
         "volunteers": {

--- a/awoostria.json
+++ b/awoostria.json
@@ -17,7 +17,39 @@
       "latLng": [
         48.18527049999999,
         16.3833476
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-11-15",
+            "source": "https://bsky.app/profile/awoostria.at/post/3m47e6goekk2o",
+            "asOf": "2025-10-27T21:25:11.274Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-01-31",
+            "source": "https://bsky.app/profile/awoostria.at/post/3mdlircoblc2a",
+            "asOf": "2026-01-29T19:15:37.832Z",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2025-11-29",
+            "source": "https://bsky.app/profile/awoostria.at/post/3m6rbabnz5c24",
+            "asOf": "2025-11-29T11:10:50.447Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-03-07",
+            "source": "https://bsky.app/profile/awoostria.at/post/3mgikvdorz22u",
+            "asOf": "2026-03-07T19:31:16.261Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "awoostria-2025",

--- a/barkada-furfest.json
+++ b/barkada-furfest.json
@@ -23,6 +23,12 @@
       ],
       "keyDates": {
         "registration": {
+          "opens": {
+            "date": "2026-04-03",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mie7rmmhdc2p",
+            "asOf": "2026-03-31T12:52:04.553Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-07-20",
             "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3modcauxwik2e",

--- a/barkada-furfest.json
+++ b/barkada-furfest.json
@@ -20,7 +20,33 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-07-20",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3modcauxwik2e",
+            "asOf": "2026-06-15T12:34:54.146Z",
+            "confidence": 0.93
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-03-30",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mibstosk3k2p",
+            "asOf": "2026-03-30T13:55:15.832Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-04-10",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mj5fttiyws2r",
+            "asOf": "2026-04-10T13:17:14.794Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "barkada-furfest-2025",

--- a/big-sky-camp-paw.json
+++ b/big-sky-camp-paw.json
@@ -20,7 +20,37 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-09",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mgngrf4f6c2l",
+            "asOf": "2026-03-09T18:00:47.268Z",
+            "confidence": 0.92
+          },
+          "closes": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mgngrf4f6c2l",
+            "asOf": "2026-03-09T18:00:47.268Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-04-25",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mkdomxepkk2a",
+            "asOf": "2026-04-25T18:35:37.705Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-25",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mkdomxepkk2a",
+            "asOf": "2026-04-25T18:35:37.705Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "big-sky-camp-paw-2025",

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -36,10 +36,24 @@
           }
         },
         "dealers": {
+          "opens": {
+            "date": "2026-04-16",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mjnfxkjmta2c",
+            "asOf": "2026-04-16T22:01:53.648Z",
+            "confidence": 0.85
+          },
           "closes": {
             "date": "2026-05-29",
             "source": "https://bsky.app/profile/goblfc.org/post/3mmza4jbnvq2n",
             "asOf": "2026-05-29T19:04:50.582Z",
+            "confidence": 0.95
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mpjse6tbyh26",
+            "asOf": "2026-06-30T20:04:14.356Z",
             "confidence": 0.95
           }
         }

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -17,7 +17,33 @@
       "latLng": [
         39.5230411,
         -119.7812235
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-05-11",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mlm6a53a6p2n",
+            "asOf": "2026-05-11T21:01:16.836Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-07-08",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mnfsgvfbny2a",
+            "asOf": "2026-06-03T19:04:43.615Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-05-29",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mmza4jbnvq2n",
+            "asOf": "2026-05-29T19:04:50.582Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "biggest-little-fur-con-2025",

--- a/brasil-furfest.json
+++ b/brasil-furfest.json
@@ -17,7 +17,17 @@
       "latLng": [
         -22.861375600000002,
         -47.14807400000001
-      ]
+      ],
+      "keyDates": {
+        "volunteers": {
+          "opens": {
+            "date": "2026-03-07",
+            "source": "https://bsky.app/profile/brasilfurfest.bsky.social/post/3mghfoc5nbc24",
+            "asOf": "2026-03-07T08:25:11.328Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "brasil-furfest-2025",

--- a/calfurry.json
+++ b/calfurry.json
@@ -17,7 +17,39 @@
       "latLng": [
         50.9803874,
         -113.9969131
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-02-07",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mebvgr2crk2g",
+            "asOf": "2026-02-07T17:00:56.274Z",
+            "confidence": 0.93
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-01-17",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mcmybmtjul2c",
+            "asOf": "2026-01-17T16:00:38.335Z",
+            "confidence": 0.92
+          },
+          "closes": {
+            "date": "2026-01-31",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mcmybmtjul2c",
+            "asOf": "2026-01-17T16:00:38.335Z",
+            "confidence": 0.92
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-24",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3moxntbl4nc2w",
+            "asOf": "2026-06-23T14:55:17.265Z",
+            "confidence": 0.93
+          }
+        }
+      }
     }
   ]
 }

--- a/camp-mani-toebeans.json
+++ b/camp-mani-toebeans.json
@@ -17,7 +17,17 @@
       "latLng": [
         50.6643681,
         -100.0189803
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-08-14",
+            "source": "https://bsky.app/profile/campmani-toebeans.bsky.social/post/3moemvejnyc23",
+            "asOf": "2026-06-16T01:17:58.645Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "camp-mani-toebeans-2025",

--- a/canfurence.json
+++ b/canfurence.json
@@ -17,7 +17,31 @@
       "latLng": [
         45.420912,
         -75.656345
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-16",
+            "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mh7kryxfks23",
+            "asOf": "2026-03-16T23:00:38.335Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-03",
+            "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mh7kryxfks23",
+            "asOf": "2026-03-16T23:00:38.335Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mjkf7sw5bs2o",
+            "asOf": "2026-04-15T17:10:39.691Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "canfurence-2025",

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-23",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mhqxg6ybnk23",
+            "asOf": "2026-03-23T21:01:56.196Z",
+            "confidence": 0.92
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-06",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mitn7s24oc22",
+            "asOf": "2026-04-06T16:02:34.722Z",
+            "confidence": 0.9
+          }
+        }
+      }
     }
   ]
 }

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -17,7 +17,39 @@
       "latLng": [
         35.7091445,
         -81.3039439
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-02-09",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mehk4dho722m",
+            "asOf": "2026-02-09T22:54:14.172Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-05-12",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mlolrkmfms22",
+            "asOf": "2026-05-12T20:08:59.621Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-25",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mmmg65ytts2h",
+            "asOf": "2026-05-24T16:48:32.305Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-12",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3movbsv4qa22i",
+            "asOf": "2026-06-22T16:14:59.831Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "carolina-furfare-2025",

--- a/confuror.json
+++ b/confuror.json
@@ -20,7 +20,31 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-07",
+            "source": "https://bsky.app/profile/confuror.bsky.social/post/3mea4ncdqkk26",
+            "asOf": "2026-02-07T00:04:32.873Z",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-20",
+            "source": "https://bsky.app/profile/confuror.bsky.social/post/3mjq53hsdnk26",
+            "asOf": "2026-04-18T00:01:02.310Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-11",
+            "source": "https://bsky.app/profile/confuror.bsky.social/post/3mlmd7e5rgc26",
+            "asOf": "2026-05-11T22:30:19.452Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "confuror-2025",

--- a/confuror.json
+++ b/confuror.json
@@ -24,9 +24,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-02-07",
-            "source": "https://bsky.app/profile/confuror.bsky.social/post/3mea4ncdqkk26",
-            "asOf": "2026-02-07T00:04:32.873Z",
+            "date": "2026-04-02",
+            "source": "https://bsky.app/profile/confuror.bsky.social/post/3mii4bqyycs22",
+            "asOf": "2026-04-02T02:00:10.006Z",
             "confidence": 0.85
           }
         },

--- a/core-element.json
+++ b/core-element.json
@@ -20,6 +20,12 @@
       ],
       "keyDates": {
         "registration": {
+          "opens": {
+            "date": "2026-03-08",
+            "source": "https://bsky.app/profile/coreelement.bsky.social/post/3mgkwbaouos23",
+            "asOf": "2026-03-08T18:00:06.403Z",
+            "confidence": 0.85
+          },
           "closes": {
             "date": "2026-07-10",
             "source": "https://bsky.app/profile/coreelement.bsky.social/post/3movit3mivc2l",

--- a/core-element.json
+++ b/core-element.json
@@ -17,7 +17,17 @@
       "latLng": [
         52.8929675,
         -1.3949577
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/coreelement.bsky.social/post/3movit3mivc2l",
+            "asOf": "2026-06-22T18:20:22.815Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "core-element-2025",

--- a/denfur.json
+++ b/denfur.json
@@ -19,6 +19,14 @@
         -104.989906
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-10-03",
+            "source": "https://bsky.app/profile/denfur.org/post/3m2cya6ts5o2d",
+            "asOf": "2025-10-03T14:11:40-07:00",
+            "confidence": 0.85
+          }
+        },
         "hotel": {
           "opens": {
             "date": "2026-01-22",

--- a/denfur.json
+++ b/denfur.json
@@ -17,7 +17,25 @@
       "latLng": [
         39.7421248,
         -104.989906
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-01-22",
+            "source": "https://bsky.app/profile/denfur.org/post/3mczoqbrjps2y",
+            "asOf": "2026-01-22T09:14:30-08:00",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-01-27",
+            "source": "https://bsky.app/profile/denfur.org/post/3mdgh3uujje2h",
+            "asOf": "2026-01-27T11:02:26-08:00",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "denfur-2025",

--- a/dutch-furcon.json
+++ b/dutch-furcon.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-07",
+            "source": "https://bsky.app/profile/dutchfurcon.com/post/3mgfikgkj322j",
+            "asOf": "2026-03-06T14:11:23.462Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "dutch-furcon-10",

--- a/east.json
+++ b/east.json
@@ -17,7 +17,17 @@
       "latLng": [
         50.61684409999999,
         10.7230377
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-15",
+            "source": "https://bsky.app/profile/sachsenfurs.de/post/3mgdjuvxrtc2r",
+            "asOf": "2026-03-05T19:29:49.437Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "east-13",

--- a/eufuria.json
+++ b/eufuria.json
@@ -30,9 +30,9 @@
         "hotel": {
           "closes": {
             "date": "2026-07-03",
-            "source": "https://bsky.app/profile/eufuria.org/post/3moiens36c62u",
-            "asOf": "2026-06-17T13:01:11.859Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/eufuria.org/post/3mpbmnnba4m2e",
+            "asOf": "2026-06-27T14:00:51.816Z",
+            "confidence": 0.95
           }
         },
         "panels": {
@@ -44,9 +44,9 @@
           },
           "closes": {
             "date": "2026-07-08",
-            "source": "https://bsky.app/profile/eufuria.org/post/3mlqedml5ap2b",
-            "asOf": "2026-05-13T13:01:15.158Z",
-            "confidence": 0.85
+            "source": "https://bsky.app/profile/eufuria.org/post/3mnrswazsqg2y",
+            "asOf": "2026-06-08T13:45:15.998Z",
+            "confidence": 0.9
           }
         }
       }

--- a/eufuria.json
+++ b/eufuria.json
@@ -17,7 +17,39 @@
       "latLng": [
         42.6498772,
         -73.7560941
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-06-19",
+            "source": "https://bsky.app/profile/eufuria.org/post/3mobrelcj6k2c",
+            "asOf": "2026-06-14T22:00:04.860Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "closes": {
+            "date": "2026-07-03",
+            "source": "https://bsky.app/profile/eufuria.org/post/3moiens36c62u",
+            "asOf": "2026-06-17T13:01:11.859Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-13",
+            "source": "https://bsky.app/profile/eufuria.org/post/3mlqedml5ap2b",
+            "asOf": "2026-05-13T13:01:15.158Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-07-08",
+            "source": "https://bsky.app/profile/eufuria.org/post/3mlqedml5ap2b",
+            "asOf": "2026-05-13T13:01:15.158Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "eufuria-2025",

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -30,8 +30,8 @@
         "dealers": {
           "closes": {
             "date": "2026-03-22",
-            "source": "https://bsky.app/profile/eurofurence.org/post/3mgfowhrd522c",
-            "asOf": "2026-03-06T16:05:29.809Z",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mhiv5bqhfs2q",
+            "asOf": "2026-03-20T15:59:51.667Z",
             "confidence": 0.95
           }
         },

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -17,7 +17,33 @@
       "latLng": [
         53.5615943,
         9.9859745
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-05-18",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mlvpa3nrok2u",
+            "asOf": "2026-05-15T15:59:26.599Z",
+            "confidence": 0.8
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-03-22",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mgfowhrd522c",
+            "asOf": "2026-03-06T16:05:29.809Z",
+            "confidence": 0.95
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mjrvabp77k2x",
+            "asOf": "2026-04-18T16:45:53.219Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "eurofurence-29",

--- a/fluufff.json
+++ b/fluufff.json
@@ -20,7 +20,39 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-04-19",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mietshbexx23",
+            "asOf": "2026-03-31T18:50:27.315Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-26",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mjx4hj3axt2o",
+            "asOf": "2026-04-20T18:38:30.711Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-24",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mm752mirfd2j",
+            "asOf": "2026-05-19T10:00:52.951Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-08-01",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mn2vit6rim2e",
+            "asOf": "2026-05-30T11:00:12.493Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "fluufff-2025",

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -44,9 +44,9 @@
         "panels": {
           "closes": {
             "date": "2026-06-30",
-            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3moy6vo563y2v",
-            "asOf": "2026-06-23T20:00:49.897045098Z",
-            "confidence": 0.85
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mpjs5wgjwj2d",
+            "asOf": "2026-06-30T20:00:44.397035309Z",
+            "confidence": 0.95
           }
         }
       }

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -17,7 +17,39 @@
       "latLng": [
         53.482442,
         -113.4929521
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-06-11",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mnhrzm6hyr2n",
+            "asOf": "2026-06-04T14:02:36.412398460Z",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-05-22",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mmazeqovyy2h",
+            "asOf": "2026-05-20T04:00:16.954773206Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-12",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mnt3ypudqh2a",
+            "asOf": "2026-06-09T02:00:21.439458030Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3moy6vo563y2v",
+            "asOf": "2026-06-23T20:00:49.897045098Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "fur-eh-2025",

--- a/fureast.json
+++ b/fureast.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-06",
+            "source": "https://bsky.app/profile/fureast.fr/post/3mc34so4k3e25",
+            "asOf": "2026-01-10T13:33:50.998Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/fureast.fr/post/3mkih54zsaa2w",
+            "asOf": "2026-04-27T16:04:49.217Z",
+            "confidence": 0.92
+          }
+        }
+      }
     },
     {
       "id": "fureast-2025",

--- a/furnavia.json
+++ b/furnavia.json
@@ -20,7 +20,45 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-06-01",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnajdiupos2e",
+            "asOf": "2026-06-01T16:38:27.470Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-06-01",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnalnlvmck2b",
+            "asOf": "2026-06-01T17:19:53.671Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3moyabjmda22z",
+            "asOf": "2026-06-23T20:25:22.808Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-06-08",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnnaah7fks2b",
+            "asOf": "2026-06-06T18:00:17.983Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-09-15",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnnaah7fks2b",
+            "asOf": "2026-06-06T18:00:17.983Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "furnavia-2025",

--- a/furpocalypse.json
+++ b/furpocalypse.json
@@ -17,7 +17,33 @@
       "latLng": [
         41.0433162,
         -73.5504412
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-06-13",
+            "source": "https://bsky.app/profile/furpocalypse.org/post/3mo6mru4qvf23",
+            "asOf": "2026-06-13T16:00:02.065Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-06-07",
+            "source": "https://bsky.app/profile/furpocalypse.org/post/3mnq64jyejs2q",
+            "asOf": "2026-06-07T22:00:18.043Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-06-20",
+            "source": "https://bsky.app/profile/furpocalypse.org/post/3moq26p5wqd2p",
+            "asOf": "2026-06-20T14:15:07.227Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "furpocalypse-2025",

--- a/furrest-city.json
+++ b/furrest-city.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-06-05",
+            "source": "https://bsky.app/profile/furrestcity.org/post/3mnldtyppck2g",
+            "asOf": "2026-06-05T23:59:35.606Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-20",
+            "source": "https://bsky.app/profile/furrestcity.org/post/3mnnnjc2wbs2f",
+            "asOf": "2026-06-06T21:57:53.201Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "furrest-city-2025",

--- a/furry-blacklight.json
+++ b/furry-blacklight.json
@@ -50,6 +50,12 @@
             "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mnmst7eeok2w",
             "asOf": "2026-06-06T14:00:14.907Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-15",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mpgqwfnlav23",
+            "asOf": "2026-06-29T15:00:39.489Z",
+            "confidence": 0.95
           }
         }
       }

--- a/furry-blacklight.json
+++ b/furry-blacklight.json
@@ -20,7 +20,39 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-04-18",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mht2fac7o22e",
+            "asOf": "2026-03-24T17:00:24.718Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-02-15",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mew4ibbair2o",
+            "asOf": "2026-02-15T18:00:18.189Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-03-15",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mgkma7qaus2i",
+            "asOf": "2026-03-08T15:00:34.438Z",
+            "confidence": 0.8
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-06-06",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mnmst7eeok2w",
+            "asOf": "2026-06-06T14:00:14.907Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "furry-blacklight-2025",

--- a/furry-migration.json
+++ b/furry-migration.json
@@ -17,7 +17,47 @@
       "latLng": [
         44.9705423,
         -93.2781067
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-25",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mfoyrn7hgb2o",
+            "asOf": "2026-02-25T15:30:31.201Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-04-24",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mkaywc22cp2j",
+            "asOf": "2026-04-24T17:01:48.172Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-11",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mjaru3gtw42o",
+            "asOf": "2026-04-11T21:30:06.414Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mn37vyxtrk2v",
+            "asOf": "2026-05-30T14:06:31.365Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-11",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mo47s6dk6c2w",
+            "asOf": "2026-06-12T17:02:14.978Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "furry-migration-2025",

--- a/furry-weekend-atlanta.json
+++ b/furry-weekend-atlanta.json
@@ -22,9 +22,9 @@
         "registration": {
           "opens": {
             "date": "2026-07-01",
-            "source": "https://bsky.app/profile/furryweekend.com/post/3mljswiw64n2i",
-            "asOf": "2026-05-10T22:33:42.683Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/furryweekend.com/post/3mpm7vel5tc2h",
+            "asOf": "2026-07-01T19:11:49.641Z",
+            "confidence": 0.95
           }
         }
       }

--- a/furry-weekend-atlanta.json
+++ b/furry-weekend-atlanta.json
@@ -17,7 +17,17 @@
       "latLng": [
         33.7615717,
         -84.3859463
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/furryweekend.com/post/3mljswiw64n2i",
+            "asOf": "2026-05-10T22:33:42.683Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "furry-weekend-atlanta-2026",

--- a/furrydelphia.json
+++ b/furrydelphia.json
@@ -17,7 +17,47 @@
       "latLng": [
         39.957391,
         -75.16726830000002
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-11-20",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3m635nrkeis24",
+            "asOf": "2025-11-20T16:08:14.103Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mlw4qz4j652b",
+            "asOf": "2026-05-15T20:01:31.968Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-02-02",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mdvx775dom2p",
+            "asOf": "2026-02-02T23:00:32.548Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-03-02",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mdvx775dom2p",
+            "asOf": "2026-02-02T23:00:32.548Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-03-11",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mgsv44q3x72b",
+            "asOf": "2026-03-11T22:00:37.409Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "furrydelphia-2025",

--- a/furrydelphia.json
+++ b/furrydelphia.json
@@ -25,6 +25,12 @@
             "source": "https://bsky.app/profile/furrydelphia.org/post/3m635nrkeis24",
             "asOf": "2025-11-20T16:08:14.103Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-19",
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mpjso4l7up2j",
+            "asOf": "2026-06-30T20:09:47.275Z",
+            "confidence": 0.9
           }
         },
         "hotel": {

--- a/fursonacon.json
+++ b/fursonacon.json
@@ -17,7 +17,17 @@
       "latLng": [
         37.0871125,
         -76.4715315
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-08-31",
+            "source": "https://bsky.app/profile/fursonacon.bsky.social/post/3lxq26znk4c2q",
+            "asOf": "2025-08-31T21:35:51.164Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "fursonacon-2025",

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -22,9 +22,9 @@
         "dealers": {
           "closes": {
             "date": "2026-06-28",
-            "source": "https://bsky.app/profile/furcon.bsky.social/post/3motbbwmbbm24",
-            "asOf": "2026-06-21T21:00:11.467Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mp7ryc6p7y2r",
+            "asOf": "2026-06-26T20:30:58.541Z",
+            "confidence": 0.95
           }
         },
         "panels": {

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -17,7 +17,25 @@
       "latLng": [
         37.3291639,
         -121.889011
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "closes": {
+            "date": "2026-06-28",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3motbbwmbbm24",
+            "asOf": "2026-06-21T21:00:11.467Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-24",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mmf7nq6q5m2f",
+            "asOf": "2026-05-21T20:03:20.286Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "further-confusion-2026",

--- a/furvester.json
+++ b/furvester.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "opens": {
+            "date": "2026-07-04",
+            "source": "https://bsky.app/profile/furvester.org/post/3movlydbobu2u",
+            "asOf": "2026-06-22T19:16:59.605Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "furvester-6",

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-05-24",
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mm2qrek6b22b",
+            "asOf": "2026-05-17T16:10:18.829Z",
+            "confidence": 0.92
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-06-21",
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mnv5mngvos2l",
+            "asOf": "2026-06-09T21:34:43.856Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "futrolajki-2025",

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -25,17 +25,33 @@
         "registration": {
           "opens": {
             "date": "2026-05-24",
-            "source": "https://bsky.app/profile/futrolajki.pl/post/3mm2qrek6b22b",
-            "asOf": "2026-05-17T16:10:18.829Z",
-            "confidence": 0.92
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mmmlbbives2a",
+            "asOf": "2026-05-24T18:19:45.334Z",
+            "confidence": 0.95
           }
         },
         "hotel": {
           "opens": {
             "date": "2026-06-21",
-            "source": "https://bsky.app/profile/futrolajki.pl/post/3mnv5mngvos2l",
-            "asOf": "2026-06-09T21:34:43.856Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mot2lgfzbc2m",
+            "asOf": "2026-06-21T19:00:13.857Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mpm42sbjck2k",
+            "asOf": "2026-07-01T18:03:16.809Z",
+            "confidence": 0.95
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-16",
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mogibcpksk2i",
+            "asOf": "2026-06-16T19:00:30.218Z",
+            "confidence": 0.85
           }
         }
       }

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -17,7 +17,41 @@
       "latLng": [
         38.6251397,
         -90.19092769999999
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-02",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mbexjvmiac2s",
+            "asOf": "2026-01-01T18:00:53.964Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-04-27",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mkikatstzl23",
+            "asOf": "2026-04-27T17:00:35.020189+00:00",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-03-01",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mfwp7dh75224",
+            "asOf": "2026-02-28T17:00:31.214832+00:00",
+            "confidence": 0.92
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-18",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mko24hbmpa2s",
+            "asOf": "2026-04-29T21:27:46.213660+00:00",
+            "confidence": 0.92
+          }
+        }
+      }
     },
     {
       "id": "gateway-furmeet-2025",

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -22,9 +22,9 @@
         "registration": {
           "opens": {
             "date": "2026-01-02",
-            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mbexjvmiac2s",
-            "asOf": "2026-01-01T18:00:53.964Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mbhi2llkh22p",
+            "asOf": "2026-01-02T18:01:53.221Z",
+            "confidence": 0.95
           }
         },
         "hotel": {

--- a/goldenhorn.json
+++ b/goldenhorn.json
@@ -20,7 +20,31 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-06-20",
+            "source": "https://bsky.app/profile/goldenhorn.si/post/3mim3qjgquppc",
+            "asOf": "2026-04-03T16:01:10.606Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-23",
+            "source": "https://bsky.app/profile/goldenhorn.si/post/3mk6bpejmbj2i",
+            "asOf": "2026-04-23T15:01:01.248Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-05",
+            "source": "https://bsky.app/profile/goldenhorn.si/post/3mmtrjqnxslql",
+            "asOf": "2026-05-27T15:00:30.301Z",
+            "confidence": 0.92
+          }
+        }
+      }
     },
     {
       "id": "goldenhorn-2025",

--- a/heartland-howloween.json
+++ b/heartland-howloween.json
@@ -25,9 +25,9 @@
         "dealers": {
           "closes": {
             "date": "2026-07-03",
-            "source": "https://bsky.app/profile/heartlandhowloween.bsky.social/post/3montyemams27",
-            "asOf": "2026-06-19T17:18:53.270Z",
-            "confidence": 0.92
+            "source": "https://bsky.app/profile/heartlandhowloween.bsky.social/post/3mpltijzw4k25",
+            "asOf": "2026-07-01T15:29:54.249Z",
+            "confidence": 0.95
           }
         }
       }

--- a/heartland-howloween.json
+++ b/heartland-howloween.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "closes": {
+            "date": "2026-07-03",
+            "source": "https://bsky.app/profile/heartlandhowloween.bsky.social/post/3montyemams27",
+            "asOf": "2026-06-19T17:18:53.270Z",
+            "confidence": 0.92
+          }
+        }
+      }
     },
     {
       "id": "heartland-howloween-2025",

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -20,7 +20,53 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-03",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mbgx6tli6c2n",
+            "asOf": "2026-01-02T13:00:02.187Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-01-17",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mcmo6sz3q222",
+            "asOf": "2026-01-17T13:00:07.989Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-03-25",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mcmo6sz3q222",
+            "asOf": "2026-01-17T13:00:07.989Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-02-02",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mduvskffdk2k",
+            "asOf": "2026-02-02T13:02:55.770Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-04-12",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mi7c6zeaps22",
+            "asOf": "2026-03-29T13:52:02.914Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "closes": {
+            "date": "2026-04-12",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mi7c6zeaps22",
+            "asOf": "2026-03-29T13:52:02.914Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "indonesia-weekend-anthro-gathering-2025",

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -44,6 +44,14 @@
             "confidence": 0.9
           }
         },
+        "dealers": {
+          "opens": {
+            "date": "2026-01-31",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mdpvgo6gfs2g",
+            "asOf": "2026-01-31T13:12:58.367Z",
+            "confidence": 0.95
+          }
+        },
         "panels": {
           "opens": {
             "date": "2026-02-02",

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -49,10 +49,10 @@
             "confidence": 0.92
           },
           "closes": {
-            "date": "2026-04-17",
-            "source": "https://bsky.app/profile/indyfurcon.org/post/3mh6mqha6wf26",
-            "asOf": "2026-03-16T14:02:53.622359Z",
-            "confidence": 0.92
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mplvipgci72m",
+            "asOf": "2026-07-01T16:05:47.057145683Z",
+            "confidence": 0.95
           }
         },
         "panels": {

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -17,7 +17,53 @@
       "latLng": [
         39.7665208,
         -86.1610453
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-19",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mcsbaye3zs2k",
+            "asOf": "2026-01-19T18:24:40.490Z",
+            "confidence": 0.88
+          },
+          "closes": {
+            "date": "2026-06-28",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mnxflnw4p32j",
+            "asOf": "2026-06-10T19:02:39.956128075Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-20",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mmc6j7hldu2e",
+            "asOf": "2026-05-20T15:04:55.363480197Z",
+            "confidence": 0.92
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-03-16",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mh6mqha6wf26",
+            "asOf": "2026-03-16T14:02:53.622359Z",
+            "confidence": 0.92
+          },
+          "closes": {
+            "date": "2026-04-17",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mh6mqha6wf26",
+            "asOf": "2026-03-16T14:02:53.622359Z",
+            "confidence": 0.92
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-05-10",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3ml6xwyhnjg2z",
+            "asOf": "2026-05-06T15:04:10.758112Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "indyfurcon-2025",

--- a/infurnity.json
+++ b/infurnity.json
@@ -50,6 +50,14 @@
             "confidence": 0.92
           }
         },
+        "panels": {
+          "closes": {
+            "date": "2026-08-15",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mpixnbjg2c23",
+            "asOf": "2026-06-30T12:06:08.853Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "closes": {
             "date": "2026-07-31",

--- a/infurnity.json
+++ b/infurnity.json
@@ -26,7 +26,39 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-06-01",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mn4qopukq225",
+            "asOf": "2026-05-31T04:39:21.144Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-25",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mmbn366lys2w",
+            "asOf": "2026-05-20T09:52:50.903Z",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mopfk2mkyc2h",
+            "asOf": "2026-06-20T08:05:40.141Z",
+            "confidence": 0.92
+          }
+        },
+        "volunteers": {
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mcms3y6ip22c",
+            "asOf": "2026-01-17T14:10:07.716Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "infurnity-2025",

--- a/lakeside-furs.json
+++ b/lakeside-furs.json
@@ -17,7 +17,17 @@
       "latLng": [
         47.501787,
         11.706208400000001
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-03",
+            "source": "https://bsky.app/profile/lakesidefurs.at/post/3manjyxymc22z",
+            "asOf": "2025-12-23T10:27:33.408Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "lakeside-furs-2025",

--- a/lakeside-furs.json
+++ b/lakeside-furs.json
@@ -22,8 +22,8 @@
         "registration": {
           "opens": {
             "date": "2026-01-03",
-            "source": "https://bsky.app/profile/lakesidefurs.at/post/3manjyxymc22z",
-            "asOf": "2025-12-23T10:27:33.408Z",
+            "source": "https://bsky.app/profile/lakesidefurs.at/post/3mbhnj53ux22s",
+            "asOf": "2026-01-02T19:39:30.050Z",
             "confidence": 0.9
           }
         }

--- a/las-vegas-fur-con.json
+++ b/las-vegas-fur-con.json
@@ -17,7 +17,17 @@
       "latLng": [
         36.1075771,
         -115.1562516
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-05-29",
+            "source": "https://bsky.app/profile/lasvegasfurcon.org/post/3mmzlqatazd2p",
+            "asOf": "2026-05-29T22:32:44.540725+00:00",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "las-vegas-fur-con-2026",

--- a/las-vegas-fur-con.json
+++ b/las-vegas-fur-con.json
@@ -26,6 +26,14 @@
             "asOf": "2026-05-29T22:32:44.540725+00:00",
             "confidence": 0.85
           }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/lasvegasfurcon.org/post/3mpjiavrk522z",
+            "asOf": "2026-06-30T17:03:27.475274+00:00",
+            "confidence": 0.95
+          }
         }
       }
     },

--- a/mephit-fur-meet.json
+++ b/mephit-fur-meet.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-02-19",
+            "source": "https://bsky.app/profile/mephitfurmeet.org/post/3mfaao6ronk2h",
+            "asOf": "2026-02-19T18:41:49.287Z",
+            "confidence": 0.82
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-04-16",
+            "source": "https://bsky.app/profile/mephitfurmeet.org/post/3mjlbed636c2f",
+            "asOf": "2026-04-16T01:34:15.718Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "mephit-fur-meet-2025",

--- a/noctfurnal.json
+++ b/noctfurnal.json
@@ -20,7 +20,33 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-05-01",
+            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mkijpprxxk2a",
+            "asOf": "2026-04-27T16:51:00.397Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-04-06",
+            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3miu75rtay22u",
+            "asOf": "2026-04-06T21:23:34.742Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2025-10-01",
+            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3m25etofg222x",
+            "asOf": "2025-10-01T15:41:21.280Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "noctfurnal-2025",

--- a/pawai.json
+++ b/pawai.json
@@ -17,7 +17,59 @@
       "latLng": [
         -8.7152656,
         115.1690945
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-01",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mfyp5kmkt22k",
+            "asOf": "2026-03-01T12:04:51.118Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mokzs6rpn22a",
+            "asOf": "2026-06-18T14:24:49.084Z",
+            "confidence": 0.95
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-04-13",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mjeo54263s2k",
+            "asOf": "2026-04-13T10:34:13.842Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-05-10",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mlin3lfjfk23",
+            "asOf": "2026-05-10T11:16:31.300Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mlin3lfjfk23",
+            "asOf": "2026-05-10T11:16:31.300Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-08",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e",
+            "asOf": "2026-05-08T11:00:42.729Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e",
+            "asOf": "2026-05-08T11:00:42.729Z",
+            "confidence": 0.85
+          }
+        }
+      }
     }
   ]
 }

--- a/pawcon.json
+++ b/pawcon.json
@@ -17,7 +17,53 @@
       "latLng": [
         37.3717721,
         -121.9227129
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-18",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mf5ltqdts22v",
+            "asOf": "2026-02-18T17:23:47.425Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mmfp65t3gk2a",
+            "asOf": "2026-05-22T00:40:57.626Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-02-19",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mf6h2s3axk2v",
+            "asOf": "2026-02-19T01:30:55.150Z",
+            "confidence": 0.9
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-06-02",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mnd66lvods2x",
+            "asOf": "2026-06-02T17:56:50.931Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mnd66lvods2x",
+            "asOf": "2026-06-02T17:56:50.931Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-08",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mleavvmtxk26",
+            "asOf": "2026-05-08T17:27:56.847Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "pawcon-2025",

--- a/pawsome.json
+++ b/pawsome.json
@@ -17,7 +17,53 @@
       "latLng": [
         51.8339728,
         -2.1883307
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-30",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mice2b53z22a",
+            "asOf": "2026-03-30T19:03:09.995Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "closes": {
+            "date": "2026-04-25",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mjrby6t6n524",
+            "asOf": "2026-04-18T11:01:20.669Z",
+            "confidence": 0.85
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-03-07",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mghosckztk22",
+            "asOf": "2026-03-07T11:08:29.662Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mghosckztk22",
+            "asOf": "2026-03-07T11:08:29.662Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mkpz4rifqr2m",
+            "asOf": "2026-04-30T16:15:22.656Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-03",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mmz3nxyhgb2f",
+            "asOf": "2026-05-29T17:45:08.297Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "pawsome-2025",

--- a/pawstral.json
+++ b/pawstral.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-04-04",
+            "source": "https://bsky.app/profile/pawstral.bsky.social/post/3min4ym5c4c2o",
+            "asOf": "2026-04-04T01:56:15.355Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-18",
+            "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mm3t3tgpwk2x",
+            "asOf": "2026-05-18T02:24:37.203Z",
+            "confidence": 0.82
+          }
+        }
+      }
     },
     {
       "id": "pawstral-2025",

--- a/purple-clouds-festival.json
+++ b/purple-clouds-festival.json
@@ -17,7 +17,17 @@
       "latLng": [
         53.07385499999999,
         8.4158131
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-04",
+            "source": "https://bsky.app/profile/purple-clouds.de/post/3mbmiv5zr3s2f",
+            "asOf": "2026-01-04T18:00:03.655Z",
+            "confidence": 0.92
+          }
+        }
+      }
     }
   ]
 }

--- a/scotiacon.json
+++ b/scotiacon.json
@@ -22,6 +22,14 @@
         "fancons.com"
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-07-20",
+            "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3mph45tk7ls2e",
+            "asOf": "2026-06-29T18:21:40.116Z",
+            "confidence": 0.95
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-07-06",

--- a/scotiacon.json
+++ b/scotiacon.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "opens": {
+            "date": "2026-07-06",
+            "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3moxwtpk2xu2b",
+            "asOf": "2026-06-23T17:36:35.556Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "scotiacon-2026",

--- a/spooktacufur.json
+++ b/spooktacufur.json
@@ -20,7 +20,33 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "opens": {
+            "date": "2026-04-21",
+            "source": "https://bsky.app/profile/spooktacufur.com/post/3mjzhpvbt3c2l",
+            "asOf": "2026-04-21T17:05:22.548Z",
+            "confidence": 0.85
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-06-19",
+            "source": "https://bsky.app/profile/spooktacufur.com/post/3mooct7c6zk2m",
+            "asOf": "2026-06-19T21:44:26.032Z",
+            "confidence": 0.95
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-05-14",
+            "source": "https://bsky.app/profile/spooktacufur.com/post/3mlt6lv6zzc2w",
+            "asOf": "2026-05-14T15:56:29.415Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "spooktacufur-2025",

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -40,10 +40,10 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-02-07",
-            "source": "https://bsky.app/profile/stratosfur.org/post/3me7idshe5t2l",
-            "asOf": "2026-02-06T18:01:19.175139Z",
-            "confidence": 0.88
+            "date": "2026-02-08",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3meejidnyko2l",
+            "asOf": "2026-02-08T18:05:03.874130Z",
+            "confidence": 0.8
           },
           "closes": {
             "date": "2026-04-07",

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -20,7 +20,53 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-10",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3meht4mvwec2k",
+            "asOf": "2026-02-10T01:35:27.540709Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-03-06",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mgbnum7ebm2l",
+            "asOf": "2026-03-05T01:35:54.500957Z",
+            "confidence": 0.92
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-02-07",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3me7idshe5t2l",
+            "asOf": "2026-02-06T18:01:19.175139Z",
+            "confidence": 0.88
+          },
+          "closes": {
+            "date": "2026-04-07",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mhvkvphf6j2m",
+            "asOf": "2026-03-25T17:01:16.649938Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-03-14",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mgy5avem7v2v",
+            "asOf": "2026-03-14T00:09:47.136058Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mijqcz5v6d2k",
+            "asOf": "2026-04-02T17:31:26.497297Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "stratosfur-2025",

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -35,6 +35,14 @@
             "confidence": 0.9
           }
         },
+        "dealers": {
+          "opens": {
+            "date": "2026-03-15",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mglvktp5ss2e",
+            "asOf": "2026-03-09T03:20:14.307Z",
+            "confidence": 0.9
+          }
+        },
         "panels": {
           "closes": {
             "date": "2026-07-15",

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -17,7 +17,33 @@
       "latLng": [
         36.0650536,
         -95.8576868
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-01-09",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mbz3ap4afi2t",
+            "asOf": "2026-01-09T18:00:34.831Z",
+            "confidence": 0.85
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-03-06",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mgfvg3an3w2m",
+            "asOf": "2026-03-06T18:01:34.870Z",
+            "confidence": 0.9
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-15",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mkkxe4uhkh2c",
+            "asOf": "2026-04-28T16:00:23.299Z",
+            "confidence": 0.88
+          }
+        }
+      }
     },
     {
       "id": "tails-and-tornadoes-fur-con-2025",

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -20,7 +20,33 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-07-27",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mo6zhdxfxt2x",
+            "asOf": "2026-06-13T19:46:48.396Z",
+            "confidence": 0.92
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mmrxdz3k7k2l",
+            "asOf": "2026-05-26T21:39:20.782Z",
+            "confidence": 0.88
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-10",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mnl2cyyt2s2v",
+            "asOf": "2026-06-05T21:09:01.788Z",
+            "confidence": 0.9
+          }
+        }
+      }
     }
   ]
 }

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -25,9 +25,17 @@
         "registration": {
           "closes": {
             "date": "2026-07-27",
-            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mo6zhdxfxt2x",
-            "asOf": "2026-06-13T19:46:48.396Z",
-            "confidence": 0.92
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mo72d6ubuv2m",
+            "asOf": "2026-06-13T20:02:22.571Z",
+            "confidence": 0.95
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-06-05",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mnk72fggdd2d",
+            "asOf": "2026-06-05T13:01:01.631Z",
+            "confidence": 0.85
           }
         },
         "dealers": {

--- a/tails-of-terror.json
+++ b/tails-of-terror.json
@@ -17,7 +17,25 @@
       "latLng": [
         -27.46243,
         153.02183549999998
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "closes": {
+            "date": "2026-08-01",
+            "source": "https://bsky.app/profile/furdu.com.au/post/3mkmftyvl4c26",
+            "asOf": "2026-04-29T05:52:28.154Z",
+            "confidence": 0.88
+          }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-06-15",
+            "source": "https://bsky.app/profile/furdu.com.au/post/3mlpyskuxk224",
+            "asOf": "2026-05-13T09:34:51.837Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "tails-of-terror-2025",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -107,6 +107,152 @@
             "items": {
               "type": "string"
             }
+          },
+          "keyDates": {
+            "type": "object",
+            "properties": {
+              "registration": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "hotel": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "dealers": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "panels": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "volunteers": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
           }
         },
         "required": ["id", "name", "url", "startDate", "endDate", "venue", "locale"]

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -20,7 +20,25 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-06-05",
+            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mnf6hof4pc2m",
+            "asOf": "2026-06-03T13:07:14.988Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-06-19",
+            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mo4xxb7aq22f",
+            "asOf": "2026-06-13T00:14:35.571Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "western-pa-furry-weekend-2025",

--- a/wild-north.json
+++ b/wild-north.json
@@ -17,7 +17,23 @@
       "latLng": [
         54.8533258,
         -1.5532642
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-03-13",
+            "source": "https://bsky.app/profile/wildnorth.bsky.social/post/3mgxm3gih7k2y",
+            "asOf": "2026-03-13T19:02:30.320Z",
+            "confidence": 0.88
+          },
+          "closes": {
+            "date": "2026-06-09",
+            "source": "https://bsky.app/profile/wildnorth.bsky.social/post/3mnd6pque522o",
+            "asOf": "2026-06-02T18:06:26.555Z",
+            "confidence": 0.85
+          }
+        }
+      }
     },
     {
       "id": "wild-north-2025",

--- a/wild-north.json
+++ b/wild-north.json
@@ -32,6 +32,14 @@
             "asOf": "2026-06-02T18:06:26.555Z",
             "confidence": 0.85
           }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/wildnorth.bsky.social/post/3mknsg26xcc2a",
+            "asOf": "2026-04-29T19:09:58.132Z",
+            "confidence": 0.9
+          }
         }
       }
     },


### PR DESCRIPTION
## Update — rolled out to all mapped cons

This started as a 3-con showcase; now it covers **every mapped con with an upcoming edition**. Second commit adds **185 key dates across 59 more cons**, hand-extracted from each con's own Bluesky (same per-field shape, confidence ≥ 0.8, deduped recency-wins, every date cites its source post + `asOf`).

⚠️ **Timing caveat:** it's late in the 2026 cycle, so of the 185 dates **~36 are still upcoming and ~149 already passed** (dealer/reg windows that opened+closed earlier this year). All accurate; the open question is presentation — whether to show past dates, hide them, or de-emphasize them in the UI. Easy to filter `date >= today` in the web component if we want pages to stay forward-looking. Flagging for a decision rather than silently dropping data.

---

## Summary
A showcase of the key-dates idea on three cons, so we can see it in the UI before deciding whether to build it out.

- Adds an optional event-level `keyDates` object: registration / hotel / dealers / panels / volunteers. Each category has `opens` and/or `closes`, and **each of those** carries `date` + `source` (the exact Bluesky post) + `asOf` (that post's timestamp) + `confidence`.
- Populates Anthrocon 2026, Biggest Little Fur Con 2026, and Eurofurence 30 — hand-extracted from their own Bluesky feeds ($0, no API).

## Why this shape
- **Per-field provenance**: opens and closes often come from different posts, so each cites its own source + freshness.
- **Additive + optional**: existing tooling/webapp ignore it unless they opt in.

## Guardrails
- Every date links its source post — nothing asserted without a citation.
- `asOf` drives a "how fresh is this" indicator; a verify note (in the web PR) points people to the official site for high-stakes dates.
- Recency-wins when re-run (a newer post supersedes), and human-curated values are never overwritten.

## Provenance / maintenance
Hand-extracted under the agreed model: I run extraction on my side and submit normal data PRs — nothing paid is wired into the repo, no secret, no scheduled job.

## Test plan
`uv run tools/materialize.py <out>` then confirm the three events carry `keyDates` in `events/*.json` + `current.jsonl`. Pairs with the `consfyi/web` PR that renders it.


## Screenshot

How this data renders on the convention page (via the consfyi/web PR):

![Key dates](https://raw.githubusercontent.com/sparkyfen/web/pr-assets-key-dates/.pr-assets/keydates-example.png)

