### PR TITLE
keyDates: performances + djs categories (schema, docs, reject grammar)

### DIFF
--- a/.github/scripts/keydates_reject.py
+++ b/.github/scripts/keydates_reject.py
@@ -17,7 +17,7 @@ import sys
 
 GRAMMAR = re.compile(
     r"^/reject\s+([a-z0-9-]+)\s+"
-    r"(registration|hotel|dealers|panels|volunteers)\.(opens|closes)\s+"
+    r"(registration|hotel|dealers|panels|performances|djs|volunteers)\.(opens|closes)\s+"
     r"(\d{4}-\d{2}-\d{2})\s*(?:[—–-]+\s*)?(.*)$",
     re.S,
 )

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ interface Series {
   /// The human-readable name for the convention series.
   name: string;
 
+  /// The convention's official Bluesky account.
+  ///
+  /// The `did` is the canonical, stable identifier for the account. The
+  /// `handle` is a human-readable cache of the account's current handle and may
+  /// change over time.
+  ///
+  /// When materialized, this is copied onto each published Event record.
+  bluesky?: {
+    did: string;
+    handle?: string;
+  };
+
   /// All instances of the convention series.
   events: Event[];
 }
@@ -130,6 +142,43 @@ interface Event {
 
   /// Sources this data is from.
   sources?: string[];
+
+  /// Lead-up deadlines for the convention instance, e.g. when registration,
+  /// hotel booking, dealer applications, panel submissions, and volunteer
+  /// signups open and close.
+  ///
+  /// These are automatically extracted from the convention's Bluesky posts,
+  /// each with a `source` citation linking to the announcement post. As such,
+  /// they may be incomplete or inaccurate, and consumers should treat the
+  /// official convention website as authoritative.
+  ///
+  /// Each deadline records the `date` (ISO 8601 yyyy-MM-dd), the `source` URI of
+  /// the announcement post it was extracted from, the `asOf` timestamp (ISO 8601
+  /// date-time) of when the source was observed, and a `confidence` between 0
+  /// and 1.
+  keyDates?: {
+    registration?: KeyDate;
+    hotel?: KeyDate;
+    dealers?: KeyDate;
+    panels?: KeyDate;
+    volunteers?: KeyDate;
+  };
+}
+
+/// An opening and/or closing deadline extracted from a convention announcement.
+interface KeyDate {
+  opens?: {
+    date: string;
+    source?: string;
+    asOf?: string;
+    confidence?: number;
+  };
+  closes?: {
+    date: string;
+    source?: string;
+    asOf?: string;
+    confidence?: number;
+  };
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ interface Event {
   sources?: string[];
 
   /// Lead-up deadlines for the convention instance, e.g. when registration,
-  /// hotel booking, dealer applications, panel submissions, and volunteer
+  /// hotel booking, dealer applications, panel submissions, performance and DJ
+  /// applications, and volunteer
   /// signups open and close.
   ///
   /// These are automatically extracted from the convention's Bluesky posts,
@@ -161,6 +162,8 @@ interface Event {
     hotel?: KeyDate;
     dealers?: KeyDate;
     panels?: KeyDate;
+    performances?: KeyDate;
+    djs?: KeyDate;
     volunteers?: KeyDate;
   };
 }

--- a/confuzzled.json
+++ b/confuzzled.json
@@ -6,6 +6,23 @@
   },
   "events": [
     {
+      "id": "confuzzled-2027",
+      "name": "ConFuzzled 2027",
+      "url": "https://confuzzled.org.uk",
+      "startDate": "2027-05-28",
+      "endDate": "2027-06-01",
+      "venue": "Hilton Birmingham Metropole",
+      "address": "Pendigo Way, Marston Green, Birmingham B40 1PP, UK",
+      "locale": "en-GB",
+      "latLng": [
+        52.4505825,
+        -1.715153
+      ],
+      "sources": [
+        "fancons.com"
+      ]
+    },
+    {
       "id": "confuzzled-2026",
       "name": "ConFuzzled 2026",
       "url": "https://confuzzled.org.uk",

--- a/slofluffcon.json
+++ b/slofluffcon.json
@@ -6,6 +6,23 @@
   },
   "events": [
     {
+      "id": "slofluffcon-2027",
+      "name": "SloFluffCon 2027",
+      "url": "https://slofluffcon.org",
+      "startDate": "2027-01-21",
+      "endDate": "2027-01-24",
+      "venue": "Grand Hotel Union",
+      "address": "Miklošičeva cesta 1, 1000 Ljubljana, Slovenija",
+      "locale": "sl-SI",
+      "latLng": [
+        46.0527237,
+        14.506327
+      ],
+      "sources": [
+        "fancons.com"
+      ]
+    },
+    {
       "id": "slofluffcon-2026",
       "name": "SloFluffCon 2026",
       "url": "https://slofluffcon.org",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -223,6 +223,62 @@
                 },
                 "additionalProperties": false
               },
+              "performances": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "djs": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
               "volunteers": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Stacked on #35 (auto-retargets to main when it merges; includes a main merge so the README edit applies to the current docs). Data half of the approved category split — the worker half is consfyi/bsky-event-ingester#5, and they must land together before the worker next runs.

- `tools/schema.json`: performances + djs mirroring the other categories (additive, +56 lines, materialize verified against the full dataset)
- README model docs: the two fields on the keyDates interface
- `/reject` grammar accepts the new categories (sandbox-retested: performances/djs rejections parse)

After both halves merge: run the one-shot migration moving the two known dance-comp dates misfiled under panels (anthrocon-2026 panels.closes 06-23, eufuria-2026 panels.closes 07-08 → performances.closes) — held out of this PR because those files are also touched by #34.