### PR TITLE
keyDates: performances + djs categories (schema + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ interface Event {
   sources?: string[];
 
   /// Lead-up deadlines for the convention instance, e.g. when registration,
-  /// hotel booking, dealer applications, panel submissions, and volunteer
+  /// hotel booking, dealer applications, panel submissions, performance and DJ
+  /// applications, and volunteer
   /// signups open and close.
   ///
   /// These are automatically extracted from the convention's Bluesky posts,
@@ -161,6 +162,8 @@ interface Event {
     hotel?: KeyDate;
     dealers?: KeyDate;
     panels?: KeyDate;
+    performances?: KeyDate;
+    djs?: KeyDate;
     volunteers?: KeyDate;
   };
 }

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -223,6 +223,62 @@
                 },
                 "additionalProperties": false
               },
+              "performances": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "djs": {
+                "type": "object",
+                "properties": {
+                  "opens": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  },
+                  "closes": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "source": { "type": "string", "format": "uri" },
+                      "asOf": { "type": "string", "format": "date-time" },
+                      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                    },
+                    "required": ["date"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
               "volunteers": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Replaces #36 (closed: its stale base made the diff show weeks of already-merged work — this is the same change rebuilt as one clean commit on main).

Adds the two new categories from the approved split:
- `tools/schema.json`: `performances` (dance comps, talent/variety shows, performer auditions) and `djs` (DJ set applications), mirroring the existing categories — additive, materialize verified against the full dataset
- README model docs: the two fields on the keyDates interface

The `/reject` grammar half moved into #35 (that file is born there). Companion PRs: worker = bsky-event-ingester#5, web UI = consfyi/web#4. Merge this before the worker next runs with the new categories; afterwards run `keydates-migrate-categories.py` (workspace) to move the two dance-comp dates misfiled under panels (anthrocon-2026, eufuria-2026).