### PR TITLE
Add Megaplex's Bluesky account

### DIFF
--- a/megaplex.json
+++ b/megaplex.json
@@ -1,5 +1,9 @@
 {
   "name": "Megaplex",
+  "bluesky": {
+    "did": "did:plc:cu4sk7befczsdrewnseop2tw",
+    "handle": "megaplexcon.org"
+  },
   "events": [
     {
       "id": "megaplex-2026",


### PR DESCRIPTION
Maps megaplex to https://bsky.app/profile/megaplexcon.org — DID resolved via the public appview (`did:plc:cu4sk7befczsdrewnseop2tw`, display name "Megaplex 2026", so it's the official account). Once merged and republished, the account shows on the con page, and megaplex joins the key-dates watchlist/sweeps automatically.