### PR TITLE
Move dance-comp deadlines from panels to performances

### DIFF
--- a/anthrocon.json
+++ b/anthrocon.json
@@ -35,7 +35,7 @@
             "confidence": 0.9
           }
         },
-        "panels": {
+        "performances": {
           "closes": {
             "date": "2026-06-23",
             "source": "https://bsky.app/profile/anthrocon.org/post/3molfwwp2ak2d",

--- a/eufuria.json
+++ b/eufuria.json
@@ -41,7 +41,9 @@
             "source": "https://bsky.app/profile/eufuria.org/post/3mlqedml5ap2b",
             "asOf": "2026-05-13T13:01:15.158Z",
             "confidence": 0.85
-          },
+          }
+        },
+        "performances": {
           "closes": {
             "date": "2026-07-08",
             "source": "https://bsky.app/profile/eufuria.org/post/3mnrswazsqg2y",


### PR DESCRIPTION
The one-shot migration documented in #38: the two dates whose source posts are dance-competition announcements move from `panels.closes` to `performances.closes` (anthrocon-2026 06-23, eufuria-2026 07-08 — evidence in the 2026-07-02 review). Everything else that belongs in the new categories was never recorded, so the worker picks those up organically. materialize verified.