### PR TITLE
Add Megaplex key dates from Bluesky

### DIFF
--- a/megaplex.json
+++ b/megaplex.json
@@ -55,20 +55,6 @@
             "confidence": 0.9
           }
         },
-        "djs": {
-          "opens": {
-            "date": "2026-03-25",
-            "source": "https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w",
-            "asOf": "2026-03-25T16:27:15.843Z",
-            "confidence": 0.85
-          },
-          "closes": {
-            "date": "2026-05-15",
-            "source": "https://bsky.app/profile/megaplexcon.org/post/3mlqosihf2r2q",
-            "asOf": "2026-05-13T16:08:31.582Z",
-            "confidence": 0.95
-          }
-        },
         "performances": {
           "opens": {
             "date": "2026-04-11",
@@ -81,6 +67,20 @@
             "source": "https://bsky.app/profile/megaplexcon.org/post/3mn6hj7iocf26",
             "asOf": "2026-05-31T21:00:31.991Z",
             "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-03-25",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w",
+            "asOf": "2026-03-25T16:27:15.843Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mlqosihf2r2q",
+            "asOf": "2026-05-13T16:08:31.582Z",
+            "confidence": 0.95
           }
         }
       }

--- a/megaplex.json
+++ b/megaplex.json
@@ -17,7 +17,73 @@
       "latLng": [
         28.42769,
         -81.4687483
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-03-11",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mgnshullop2u",
+            "asOf": "2026-03-09T21:30:12.834Z",
+            "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-03-25",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w",
+            "asOf": "2026-03-25T16:27:15.843Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-04-10",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3miwpyhwvjd2p",
+            "asOf": "2026-04-07T21:30:08.213Z",
+            "confidence": 0.95
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-03-25",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w",
+            "asOf": "2026-03-25T16:27:15.843Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mltpnjlxej24",
+            "asOf": "2026-05-14T21:01:37.958Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-03-25",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w",
+            "asOf": "2026-03-25T16:27:15.843Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mlqosihf2r2q",
+            "asOf": "2026-05-13T16:08:31.582Z",
+            "confidence": 0.95
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-04-11",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mja7l72apw2w",
+            "asOf": "2026-04-11T16:03:01.657Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-15",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mn6hj7iocf26",
+            "asOf": "2026-05-31T21:00:31.991Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "megaplex-2025",


### PR DESCRIPTION
Key dates for **megaplex-2026** extracted from the con's own Bluesky feed (@megaplexcon.org), verified against the worker's strict rubric. Previous edition (megaplex-2025) ended 2025-09-01; all source posts are 2026-dated, so edition attribution is unambiguous (single upcoming edition).

### Applied

- **hotel.opens → 2026-03-11** (conf 0.95)
  > "The #MEGAPLEX 2026 Room block officially opens in Two days, 3/11 @ 12pm EST." — [source](https://bsky.app/profile/megaplexcon.org/post/3mgnshullop2u)
- **dealers.opens → 2026-03-25** (conf 0.85)
  > "Dealers, Panels AND DJ apps are all OPEN." — [source](https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w)
- **dealers.closes → 2026-04-10** (conf 0.95)
  > "the 2026 dealer's den applications will be closing on April 10th at 11:59pm!" — [source](https://bsky.app/profile/megaplexcon.org/post/3miwpyhwvjd2p)
- **panels.opens → 2026-03-25** (conf 0.85)
  > "Dealers, Panels AND DJ apps are all OPEN." — [source](https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w)
- **panels.closes → 2026-05-15** (conf 0.9)
  > "Tomorrow is the LAST day to submit a panel for Megaplex so get them in ASAP!" (posted 2026-05-14) — [source](https://bsky.app/profile/megaplexcon.org/post/3mltpnjlxej24)
- **djs.opens → 2026-03-25** (conf 0.85)
  > "Dealers, Panels AND DJ apps are all OPEN." — [source](https://bsky.app/profile/megaplexcon.org/post/3mhviyuzsg22w)
- **djs.closes → 2026-05-15** (conf 0.95)
  > "Your LAST chance to apply to DJ for Megaplex ... Applications close in just TWO days on May 15th!" — [source](https://bsky.app/profile/megaplexcon.org/post/3mlqosihf2r2q)
- **performances.opens → 2026-04-11** (conf 0.85)
  > "registration for the 2026 Megaplex Dance Competition is officially OPEN!" — [source](https://bsky.app/profile/megaplexcon.org/post/3mja7l72apw2w)
- **performances.closes → 2026-06-15** (conf 0.9)
  > "Applications for Furry Idol are still for #MEGAPLEX 2026! Apps close June 15!" — [source](https://bsky.app/profile/megaplexcon.org/post/3mn6hj7iocf26)

Note on **performances**: this category holds two sub-events. `opens` reflects the Dance Competition opening (2026-04-11, most recent), superseding the earlier Furry Idol open (2026-03-30) per recency-wins; `closes` reflects the latest performer deadline (Furry Idol, 2026-06-15).

### Considered but dropped

- **Pre-reg price increase** ("Prices will be going up soon, save your money by purchasing your reg TODAY!", 2026-06-09) — price-tier change, registration stays open, no explicit date. Not registration.closes.
- **Dealer "reg is now open"** ("Megaplex 2026 Dealers! Your reg is now open!", 2026-04-05) — ambiguous; reads as the accepted-dealer registration/payment stage, not the application open (dealers.opens already dated by the 2026-03-25 apps-open post).
- **Furry Idol opens** ("Applications for Furry Idol are now OPEN ... Apps close May 15!", 2026-03-30) — valid performances.opens but superseded by the newer Dance Competition open (2026-04-11) under recency-wins.
- **Earlier DJ close May 1** ("DJ apps ... will CLOSE end of day May 1st", 2026-04-28) — superseded; apps were later extended to May 15 ("we've extended ALL DJ applications to May 15", 2026-05-01).
- **Earlier Furry Idol close May 15** (2026-03-30 / 2026-05-04) — superseded by the June 15 extension.
- **Room deposit charge** ("The deposit for the room is required!", 2026-03-18) — payment deadline for already-booked rooms, not a hotel open/close.
- **Party floor** ("Email MP-Hotel to secure a spot", 2026-04-22) — not a key date.
- **Pool renovation / "open room block" reminders** (2026-03-04, 2026-03-11) — no new date.
- **2025 posts** (Howl-O-Plex DJ lineup, Come Out With Pride, etc.) — different event/edition, predate the 2025 edition's end.
