### PR TITLE
Key dates from Bluesky

### DIFF
--- a/adelaide-anthros.json
+++ b/adelaide-anthros.json
@@ -62,6 +62,28 @@
             "asOf": "2026-06-21T05:30:07.834Z",
             "confidence": 0.9
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-06-21",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t",
+            "asOf": "2026-06-21T05:30:07.834Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-08-21",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t",
+            "asOf": "2026-06-21T05:30:07.834Z",
+            "confidence": 0.95
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-07-03",
+            "source": "https://bsky.app/profile/adlanthros.bsky.social/post/3mpqfecro2g2a",
+            "asOf": "2026-07-03T11:00:18.529Z",
+            "confidence": 0.9
+          }
         }
       }
     }

--- a/alamo-city-furry-invasion.json
+++ b/alamo-city-furry-invasion.json
@@ -62,6 +62,22 @@
             "asOf": "2026-05-30T17:00:45.745Z",
             "confidence": 0.9
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-18",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mm5dymqs5k2q",
+            "asOf": "2026-05-18T16:59:42.873Z",
+            "confidence": 0.8
+          }
+        },
+        "djs": {
+          "closes": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mn3jnkakk224",
+            "asOf": "2026-05-30T17:00:45.745Z",
+            "confidence": 0.95
+          }
         }
       }
     },

--- a/anthro-irish.json
+++ b/anthro-irish.json
@@ -25,6 +25,12 @@
             "source": "https://bsky.app/profile/anthro.irish/post/3m2pd7bxpd22d",
             "asOf": "2025-10-08T18:59:58.670Z",
             "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-02-13",
+            "source": "https://bsky.app/profile/anthro.irish/post/3merednqjuk2b",
+            "asOf": "2026-02-13T20:37:34.766Z",
+            "confidence": 0.9
           }
         },
         "panels": {
@@ -39,6 +45,14 @@
             "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",
             "asOf": "2026-05-07T18:06:59.029Z",
             "confidence": 0.85
+          }
+        },
+        "performances": {
+          "closes": {
+            "date": "2026-06-04",
+            "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",
+            "asOf": "2026-05-07T18:06:59.029Z",
+            "confidence": 0.9
           }
         }
       }

--- a/anthro-new-mexico.json
+++ b/anthro-new-mexico.json
@@ -21,9 +21,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2025-11-06",
-            "source": "https://bsky.app/profile/anthronewmexico.bsky.social/post/3m4yg3emohc2f",
-            "asOf": "2025-11-06T20:35:49.400Z",
+            "date": "2026-06-26",
+            "source": "https://bsky.app/profile/anthronewmexico.bsky.social/post/3mp7hkfa5nk2r",
+            "asOf": "2026-06-26T17:24:14.566Z",
             "confidence": 0.9
           }
         },

--- a/anthro-socal.json
+++ b/anthro-socal.json
@@ -62,6 +62,28 @@
             "asOf": "2026-06-22T17:00:00.000Z",
             "confidence": 0.92
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mkqdyzt2db2j",
+            "asOf": "2026-04-30T19:30:07.000Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-06-15",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mobf7hzqc22z",
+            "asOf": "2026-06-14T18:22:28.769Z",
+            "confidence": 0.95
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-04-10",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mj5vo6drq22p",
+            "asOf": "2026-04-10T18:00:23.000Z",
+            "confidence": 0.95
+          }
         }
       }
     },

--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -69,6 +69,28 @@
             "confidence": 0.95
           }
         },
+        "performances": {
+          "opens": {
+            "date": "2026-05-14",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mltj4wdejs25",
+            "asOf": "2026-05-14T19:04:58.458Z",
+            "confidence": 0.85
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-03-16",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t",
+            "asOf": "2026-03-17T02:05:44.665Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-04-17",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mjmyhfzgfk2i",
+            "asOf": "2026-04-16T18:00:15.163Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-01-30",

--- a/aurawra.json
+++ b/aurawra.json
@@ -63,6 +63,14 @@
             "confidence": 0.95
           }
         },
+        "performances": {
+          "closes": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
+            "asOf": "2026-06-04T05:49:59.850Z",
+            "confidence": 0.8
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-03-23",

--- a/awoostria.json
+++ b/awoostria.json
@@ -48,6 +48,30 @@
             "asOf": "2026-03-07T19:31:16.261Z",
             "confidence": 0.88
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-03-16",
+            "source": "https://bsky.app/profile/awoostria.at/post/3mh72r2xa5s2o",
+            "asOf": "2026-03-16T18:13:46.986Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-03-16",
+            "source": "https://bsky.app/profile/awoostria.at/post/3mh72r2xa5s2o",
+            "asOf": "2026-03-16T18:13:46.986Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-04-16",
+            "source": "https://bsky.app/profile/awoostria.at/post/3mjmqdyjmvs2z",
+            "asOf": "2026-04-16T15:35:10.427Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/barkada-furfest.json
+++ b/barkada-furfest.json
@@ -52,6 +52,14 @@
             "confidence": 0.95
           }
         },
+        "performances": {
+          "opens": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mpiva53zvc2a",
+            "asOf": "2026-06-30T11:23:00.526Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-04-10",

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -57,6 +57,14 @@
             "confidence": 0.95
           }
         },
+        "djs": {
+          "closes": {
+            "date": "2026-05-17",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mloldwqaxs2y",
+            "asOf": "2026-05-12T20:01:21.750Z",
+            "confidence": 0.95
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-04-17",

--- a/brasil-furfest.json
+++ b/brasil-furfest.json
@@ -19,12 +19,28 @@
         -47.14807400000001
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2025-09-20",
+            "source": "https://bsky.app/profile/brasilfurfest.bsky.social/post/3lza7jana7k2n",
+            "asOf": "2025-09-20T01:18:50.188Z",
+            "confidence": 0.9
+          }
+        },
         "panels": {
           "opens": {
             "date": "2026-05-01",
             "source": "https://bsky.app/profile/brasilfurfest.bsky.social/post/3mk55cx7myk24",
             "asOf": "2026-04-23T04:09:49.954Z",
             "confidence": 0.85
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-05-12",
+            "source": "https://bsky.app/profile/brasilfurfest.bsky.social/post/3mln6ameot22b",
+            "asOf": "2026-05-12T06:34:12.660Z",
+            "confidence": 0.8
           }
         },
         "volunteers": {

--- a/calfurry.json
+++ b/calfurry.json
@@ -43,16 +43,24 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-02-28",
-            "source": "https://bsky.app/profile/calfurry.ca/post/3mfmjudnsx22i",
-            "asOf": "2026-02-24T15:58:15.915Z",
-            "confidence": 1
+            "date": "2026-03-01",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mfze674wk42i",
+            "asOf": "2026-03-01T18:21:00.951Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-07-24",
             "source": "https://bsky.app/profile/calfurry.ca/post/3moxntbl4nc2w",
             "asOf": "2026-06-23T14:55:17.265Z",
             "confidence": 0.93
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-02-28",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mfmjudnsx22i",
+            "asOf": "2026-02-24T15:58:15.915Z",
+            "confidence": 0.9
           }
         },
         "volunteers": {

--- a/canfurence.json
+++ b/canfurence.json
@@ -42,6 +42,12 @@
           }
         },
         "panels": {
+          "opens": {
+            "date": "2026-01-15",
+            "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mcilmghkyk2w",
+            "asOf": "2026-01-15T22:03:24.418Z",
+            "confidence": 0.95
+          },
           "closes": {
             "date": "2026-05-16",
             "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mlwraxur6c2r",

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -49,6 +49,14 @@
             "confidence": 0.9
           }
         },
+        "djs": {
+          "closes": {
+            "date": "2026-07-12",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mpybpej7ts2u",
+            "asOf": "2026-07-06T14:16:12.594Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-06-10",

--- a/eufuria.json
+++ b/eufuria.json
@@ -48,7 +48,7 @@
             "date": "2026-07-08",
             "source": "https://bsky.app/profile/eufuria.org/post/3mnrswazsqg2y",
             "asOf": "2026-06-08T13:45:15.998Z",
-            "confidence": 0.9
+            "confidence": 1
           }
         },
         "volunteers": {

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -20,6 +20,12 @@
       ],
       "keyDates": {
         "registration": {
+          "opens": {
+            "date": "2026-02-08",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mddqnjlbwc2j",
+            "asOf": "2026-01-26T17:15:22.873Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-05-18",
             "source": "https://bsky.app/profile/eurofurence.org/post/3mlvpa3nrok2u",
@@ -43,16 +49,38 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-04-03",
-            "source": "https://bsky.app/profile/eurofurence.org/post/3milydmx2322y",
-            "asOf": "2026-04-03T15:00:16.803Z",
-            "confidence": 1
+            "date": "2026-05-11",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mlljzcdbk22g",
+            "asOf": "2026-05-11T14:59:32.612Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-05-31",
             "source": "https://bsky.app/profile/eurofurence.org/post/3mjrvabp77k2x",
             "asOf": "2026-04-18T16:45:53.219Z",
             "confidence": 0.85
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-04-06",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mitn37gitk2g",
+            "asOf": "2026-04-06T16:00:00.866Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-03-09",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mgna2uldwc2v",
+            "asOf": "2026-03-09T16:00:49.261Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-05-31",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mjrvabp77k2x",
+            "asOf": "2026-04-18T16:45:53.219Z",
+            "confidence": 0.9
           }
         }
       }

--- a/fluufff.json
+++ b/fluufff.json
@@ -51,6 +51,22 @@
             "asOf": "2026-05-30T11:00:12.493Z",
             "confidence": 0.85
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-06-07",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mnp3tcqcr323",
+            "asOf": "2026-06-07T11:46:41.582Z",
+            "confidence": 0.95
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-21",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3moscjy2ck42i",
+            "asOf": "2026-06-21T11:49:55.422Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -41,6 +41,14 @@
             "confidence": 0.95
           }
         },
+        "performances": {
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mpjs5wgjwj2d",
+            "asOf": "2026-06-30T20:00:44.397035309Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-07-02",

--- a/furnavia.json
+++ b/furnavia.json
@@ -43,6 +43,28 @@
             "asOf": "2026-06-23T20:25:22.808Z",
             "confidence": 0.9
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-06-08",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnrn6kwfts2g",
+            "asOf": "2026-06-08T12:02:32.371Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-09-15",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mnnaah7fks2b",
+            "asOf": "2026-06-06T18:00:17.983Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-26",
+            "source": "https://bsky.app/profile/furnavia.bsky.social/post/3mp7d6ynhxc2n",
+            "asOf": "2026-06-26T16:06:17.302Z",
+            "confidence": 0.8
+          }
         }
       }
     },

--- a/furrest-city.json
+++ b/furrest-city.json
@@ -37,6 +37,20 @@
             "asOf": "2026-06-06T21:57:53.201Z",
             "confidence": 0.9
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-06-19",
+            "source": "https://bsky.app/profile/furrestcity.org/post/3mom6rfbzls2w",
+            "asOf": "2026-06-19T01:26:30.796Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-09-18",
+            "source": "https://bsky.app/profile/furrestcity.org/post/3mom6rfbzls2w",
+            "asOf": "2026-06-19T01:26:30.796Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/furry-blacklight.json
+++ b/furry-blacklight.json
@@ -24,10 +24,10 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-04-18",
-            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mht2fac7o22e",
-            "asOf": "2026-03-24T17:00:24.718Z",
-            "confidence": 0.9
+            "date": "2026-05-09",
+            "source": "https://bsky.app/profile/fblacklight.bsky.social/post/3mlgtanjrzc2p",
+            "asOf": "2026-05-09T18:01:24.249Z",
+            "confidence": 0.95
           }
         },
         "dealers": {

--- a/furry-migration.json
+++ b/furry-migration.json
@@ -56,6 +56,14 @@
             "asOf": "2026-06-12T17:02:14.978Z",
             "confidence": 0.85
           }
+        },
+        "djs": {
+          "closes": {
+            "date": "2026-07-11",
+            "source": "https://bsky.app/profile/furrymigration.org/post/3mo47s6dk6c2w",
+            "asOf": "2026-06-12T17:02:14.978Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -40,6 +40,20 @@
             "asOf": "2026-05-21T20:03:20.286Z",
             "confidence": 0.9
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-05-21",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mmentnmj7c2k",
+            "asOf": "2026-05-21T14:44:31.609Z",
+            "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-06-24",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mmf7nq6q5m2f",
+            "asOf": "2026-05-21T20:03:20.286Z",
+            "confidence": 0.95
+          }
         }
       }
     },
@@ -55,7 +69,17 @@
       "latLng": [
         37.3291639,
         -121.889011
-      ]
+      ],
+      "keyDates": {
+        "volunteers": {
+          "opens": {
+            "date": "2026-01-17",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mcmzxtpqym24",
+            "asOf": "2026-01-17T16:30:58.515Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "further-confusion-2025",

--- a/furvester.json
+++ b/furvester.json
@@ -28,6 +28,12 @@
             "source": "https://bsky.app/profile/furvester.org/post/3movlydbobu2u",
             "asOf": "2026-06-22T19:16:59.605Z",
             "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-07-18",
+            "source": "https://bsky.app/profile/furvester.org/post/3mptncxdivl2r",
+            "asOf": "2026-07-04T18:00:42.097Z",
+            "confidence": 0.9
           }
         }
       }

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -46,6 +46,14 @@
             "confidence": 0.9
           }
         },
+        "djs": {
+          "opens": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/futrolajki.pl/post/3mpjluz2uv224",
+            "asOf": "2026-06-30T18:08:23.260Z",
+            "confidence": 0.95
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-06-16",

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -36,6 +36,12 @@
           }
         },
         "dealers": {
+          "opens": {
+            "date": "2026-01-02",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mbhi2llkh22p",
+            "asOf": "2026-01-02T18:01:53.221Z",
+            "confidence": 0.8
+          },
           "closes": {
             "date": "2026-03-01",
             "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mfwp7dh75224",
@@ -49,6 +55,22 @@
             "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mko24hbmpa2s",
             "asOf": "2026-04-29T21:27:46.213660+00:00",
             "confidence": 0.92
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-14",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mlrj6phvch2h",
+            "asOf": "2026-05-14T00:00:38.875376+00:00",
+            "confidence": 0.85
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-01-28",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mdixmon4hk24",
+            "asOf": "2026-01-28T19:03:29.516Z",
+            "confidence": 0.85
           }
         }
       }

--- a/goldenhorn.json
+++ b/goldenhorn.json
@@ -43,6 +43,14 @@
             "asOf": "2026-05-27T15:00:30.301Z",
             "confidence": 0.92
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-05-19",
+            "source": "https://bsky.app/profile/goldenhorn.si/post/3mm7ntzbgy22h",
+            "asOf": "2026-05-19T15:01:25.104Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -24,9 +24,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-01-03",
-            "source": "https://bsky.app/profile/iwag.furries.id/post/3mbgx6tli6c2n",
-            "asOf": "2026-01-02T13:00:02.187Z",
+            "date": "2026-07-03",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mpq7rgevqc27",
+            "asOf": "2026-07-03T09:20:16.269Z",
             "confidence": 0.9
           }
         },
@@ -66,7 +66,27 @@
             "confidence": 0.9
           }
         },
+        "djs": {
+          "opens": {
+            "date": "2026-02-05",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3me4h5lu72k2p",
+            "asOf": "2026-02-05T13:01:58.186Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-04-12",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mj7tlzqorc2m",
+            "asOf": "2026-04-11T12:28:44.770Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
+          "opens": {
+            "date": "2026-01-24",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3md5zx7deak2t",
+            "asOf": "2026-01-24T10:45:52.926Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-04-12",
             "source": "https://bsky.app/profile/iwag.furries.id/post/3mi7c6zeaps22",

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -57,6 +57,22 @@
             "confidence": 0.9
           }
         },
+        "performances": {
+          "opens": {
+            "date": "2026-05-15",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mlvm4osnqc2x",
+            "asOf": "2026-05-15T15:03:51.046596Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "closes": {
+            "date": "2026-04-01",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3miedunyalm2y",
+            "asOf": "2026-03-31T14:05:21.368827Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-01-26",

--- a/infurnity.json
+++ b/infurnity.json
@@ -34,6 +34,12 @@
             "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mn4qopukq225",
             "asOf": "2026-05-31T04:39:21.144Z",
             "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-05-25",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mmbn366lys2w",
+            "asOf": "2026-05-20T09:52:50.903Z",
+            "confidence": 0.9
           }
         },
         "dealers": {
@@ -49,6 +55,22 @@
             "date": "2026-08-15",
             "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mpixnbjg2c23",
             "asOf": "2026-06-30T12:06:08.853Z",
+            "confidence": 0.9
+          }
+        },
+        "performances": {
+          "closes": {
+            "date": "2026-09-01",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mpvks42k4k2a",
+            "asOf": "2026-07-05T12:20:48.850Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "closes": {
+            "date": "2026-08-01",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mpsokj5goc2k",
+            "asOf": "2026-07-04T08:50:09.893Z",
             "confidence": 0.9
           }
         },

--- a/nordicfuzzcon.json
+++ b/nordicfuzzcon.json
@@ -34,7 +34,17 @@
       "latLng": [
         55.607661,
         12.9941535
-      ]
+      ],
+      "keyDates": {
+        "volunteers": {
+          "opens": {
+            "date": "2026-01-12",
+            "source": "https://bsky.app/profile/nordicfuzzcon.org/post/3mcau5qmihk27",
+            "asOf": "2026-01-12T20:14:57.514Z",
+            "confidence": 0.85
+          }
+        }
+      }
     }
   ]
 }

--- a/pawai.json
+++ b/pawai.json
@@ -68,6 +68,20 @@
             "asOf": "2026-05-08T11:00:42.729Z",
             "confidence": 0.85
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-08",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e",
+            "asOf": "2026-05-08T11:00:42.729Z",
+            "confidence": 0.8
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e",
+            "asOf": "2026-05-08T11:00:42.729Z",
+            "confidence": 0.8
+          }
         }
       }
     }

--- a/pawcon.json
+++ b/pawcon.json
@@ -56,6 +56,14 @@
             "asOf": "2026-05-08T17:27:56.847Z",
             "confidence": 0.88
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-08",
+            "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mleavvmtxk26",
+            "asOf": "2026-05-08T17:27:56.847Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/pawsome.json
+++ b/pawsome.json
@@ -62,6 +62,20 @@
             "asOf": "2026-05-29T17:45:08.297Z",
             "confidence": 0.88
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-04-17",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mjphay5zcv2g",
+            "asOf": "2026-04-17T17:30:23.503Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-07",
+            "source": "https://bsky.app/profile/pawsome.bsky.social/post/3mnao655kv32o",
+            "asOf": "2026-06-01T18:04:56.100Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -22,6 +22,14 @@
         "fancons.com"
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-02-10",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3meht4mvwec2k",
+            "asOf": "2026-02-10T01:35:27.540709Z",
+            "confidence": 0.95
+          }
+        },
         "hotel": {
           "opens": {
             "date": "2026-03-06",
@@ -50,6 +58,42 @@
             "source": "https://bsky.app/profile/stratosfur.org/post/3mgy5avem7v2v",
             "asOf": "2026-03-14T00:09:47.136058Z",
             "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-06-24",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mgy5avem7v2v",
+            "asOf": "2026-03-14T00:09:47.136058Z",
+            "confidence": 0.9
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-08",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mletld5ecc25",
+            "asOf": "2026-05-08T23:02:02.799166Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-02-11",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mem2or4fmx25",
+            "asOf": "2026-02-11T18:01:30.972540Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-04-30",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mijqcz5v6d2k",
+            "asOf": "2026-04-02T17:31:26.497297Z",
+            "confidence": 0.9
+          }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-11",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mo2ezv2eix2d",
+            "asOf": "2026-06-11T23:30:42.724204Z",
+            "confidence": 0.8
           }
         }
       }

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -44,11 +44,25 @@
           }
         },
         "panels": {
+          "opens": {
+            "date": "2026-04-28",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mkknfyqtee24",
+            "asOf": "2026-04-28T13:02:28.674Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-07-01",
             "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mpkhpol2ak25",
             "asOf": "2026-07-01T02:26:29.236Z",
             "confidence": 1
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-09",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mlh4t5lnh223",
+            "asOf": "2026-05-09T20:52:47.536Z",
+            "confidence": 0.9
           }
         }
       }

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -38,11 +38,33 @@
             "confidence": 0.95
           }
         },
+        "dealers": {
+          "closes": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mmrxdz3k7k2l",
+            "asOf": "2026-05-26T21:39:20.782Z",
+            "confidence": 0.8
+          }
+        },
         "panels": {
+          "opens": {
+            "date": "2026-06-01",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mnako4mstk2y",
+            "asOf": "2026-06-01T17:02:17.300Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-06-09",
             "source": "https://bsky.app/profile/tailsofsummer.com/post/3mnuk46bljh2j",
             "asOf": "2026-06-09T15:45:29.948Z",
+            "confidence": 0.9
+          }
+        },
+        "djs": {
+          "closes": {
+            "date": "2026-06-10",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mng4appn4h2y",
+            "asOf": "2026-06-03T22:00:12.304Z",
             "confidence": 0.9
           }
         }

--- a/tails-of-terror.json
+++ b/tails-of-terror.json
@@ -46,6 +46,20 @@
             "asOf": "2026-04-29T05:52:28.154Z",
             "confidence": 0.9
           }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-05-13",
+            "source": "https://bsky.app/profile/furdu.com.au/post/3mlpyskuxk224",
+            "asOf": "2026-05-13T09:34:51.837Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-15",
+            "source": "https://bsky.app/profile/furdu.com.au/post/3mlpyskuxk224",
+            "asOf": "2026-05-13T09:34:51.837Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -24,10 +24,10 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-06-05",
-            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mnf6hof4pc2m",
-            "asOf": "2026-06-03T13:07:14.988Z",
-            "confidence": 0.9
+            "date": "2026-06-06",
+            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mnlk3u5bek2h",
+            "asOf": "2026-06-06T01:51:21.714Z",
+            "confidence": 0.95
           }
         },
         "hotel": {


### PR DESCRIPTION
> **Reviewer note:** `stratosfur` contributed 6 applied dates with 0 refuted this round. It has a
> history of verifier inconsistency (two "is open now" promo posts were unanimously confirmed in
> error and reverted in data#34), so give its entries a closer look before merging.

## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-06_

### Applied (unanimously verified)

**adelaide-anthros.json** — `adelaide-anthros-2026` volunteers.opens → **2026-07-03** (add, conf 0.9)
> Paws up for volunteers! 🐾 We're opening volunteer apps and we want YOU! Join the team to help us build an unforgettable weekend and contribute to making A2 bigger and better, while earning some sweet rewards! 📋️ Apply here! tinyurl.com/adelaideanth...
> — [source post](https://bsky.app/profile/adlanthros.bsky.social/post/3mpqfecro2g2a) at 2026-07-03T11:00:18.529Z

**adelaide-anthros.json** — `adelaide-anthros-2026` djs.opens → **2026-06-21** (add, conf 0.95)
> ALL PAWS ON DECKS! 🎛️🐾 DJ applications for A2 are live! ⏱️ Apps close Aug 21st - lock in your set now! forms.gle/3T7DZ9mXVgm7...
> — [source post](https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t) at 2026-06-21T05:30:07.834Z

**adelaide-anthros.json** — `adelaide-anthros-2026` djs.closes → **2026-08-21** (add, conf 0.95)
> ALL PAWS ON DECKS! 🎛️🐾 DJ applications for A2 are live! ⏱️ Apps close Aug 21st - lock in your set now! forms.gle/3T7DZ9mXVgm7...
> — [source post](https://bsky.app/profile/adlanthros.bsky.social/post/3morncud2hv2t) at 2026-06-21T05:30:07.834Z

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` djs.closes → **2026-06-01** (add, conf 0.95)
> Do you have what it takes to shift this party into top gear? DJ submissions are now open! Send us your hottest demo from now until June 1st! www.furryinvasion.org/dj-submission #ACFI2026
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3mitqjwomtc2y) at 2026-04-06T17:01:56.353Z

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` djs.closes → **2026-07-01** (amend 2026-06-01 -> 2026-07-01, conf 0.95)
> The pic says it all! The deadline for #ACFI2026 DJ submissions has been extended to July 1st! Submit your mix today! www.furryinvasion.org/dj-submission
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3mn3jnkakk224) at 2026-05-30T17:00:45.745Z

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` performances.opens → **2026-05-06** (add, conf 0.8)
> Come show off your moves at the Dance Competition! All skill levels are welcome! If you’re just getting a start in costumed dance or if you're a veteran dancer we’d love to have you be part of our show! Sign ups are open now! www.furryinvasion.org/event-signups #ACFI2026 📸KiloFoto
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3ml7jl3ox322x) at 2026-05-06T20:19:39.081Z

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` performances.opens → **2026-05-08** (amend 2026-05-06 -> 2026-05-08, conf 0.8)
> Interested in one-on-one dance battles? Sign up for the Dance-Off and face off against other dancers while DJ Hexa hits you with ever-changing music to move to! Sign ups are open now! www.furryinvasion.org/event-signups #ACFI2026 📸KiloFoto
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3mlepbw4ces25) at 2026-05-08T21:45:12.379Z

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` performances.opens → **2026-05-18** (amend 2026-05-08 -> 2026-05-18, conf 0.8)
> Want to run away with the circus? If you got the talent to leave the audience in shock or the jokes you can shake a rubber chicken at then join us on the silly circuit and sign up for the Great Furry Circus! www.furryinvasion.org/event-signups #ACFI2026 📸theyareClover
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3mm5dymqs5k2q) at 2026-05-18T16:59:42.873Z

**anthro-irish.json** — `anthro-irish-2026` registration.closes → **2026-02-13** (add, conf 0.9)
> ANTHRO IRISH 2026 SOLD OUT Yar mateys! How goes yere voyage on these high seas! All entry level tickets for AnthroIrish 2026 are now sold out, along with the pre-order of size M T-Shirts! Thanks to ye all for the support, and we can't wait for ye to board our ship this August.
> — [source post](https://bsky.app/profile/anthro.irish/post/3merednqjuk2b) at 2026-02-13T20:37:34.766Z

**anthro-irish.json** — `anthro-irish-2026` performances.closes → **2026-06-04** (add, conf 0.9)
> ✨️Variety Show Applications!✨️ Applications for the Anthroirish 2026 variety show are now open! ✨️🎤🎸 Applications are open from May 7th 2026 - June 4th (closing @7PM). Please fill in the below form to apply: forms.gle/gwf1m6yWmoJZ... Photo by Zuki
> — [source post](https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24) at 2026-05-07T18:06:59.029Z

**anthro-new-mexico.json** — `anthro-new-mexico-2026` registration.opens → **2026-06-26** (amend 2025-11-06 -> 2026-06-26, conf 0.9)
> Hello ghosts and ghouls, we are here at the Crowne Plaza!!! Who's ready for the coolest con Albuquerque's ever seen? Registration and hotel rooms are open, so book them while you can anthronewmexico.com
> — [source post](https://bsky.app/profile/anthronewmexico.bsky.social/post/3mp7hkfa5nk2r) at 2026-06-26T17:24:14.566Z

**anthro-socal.json** — `anthro-socal-2026` performances.opens → **2026-04-30** (add, conf 0.95)
> The #ASC2026 Performer Application is now accepting responses! We had a few performers last year but we're looking to increase our shares of the stage; you can apply below! Applications close June 15th, 2026. 🩵 anthrosocal.org/prog...
> — [source post](https://bsky.app/profile/anthrosocal.org/post/3mkqdyzt2db2j) at 2026-04-30T19:30:07.000Z

**anthro-socal.json** — `anthro-socal-2026` performances.closes → **2026-06-15** (add, conf 0.95)
> This is your reminder for #ASC2026 Performer Apps -- it's closing TOMORROW, June 15, at 11:59PM Pacific time! Get your applications in before then! 💙 anthrosocal.org/programming/...
> — [source post](https://bsky.app/profile/anthrosocal.org/post/3mobf7hzqc22z) at 2026-06-14T18:22:28.769Z

**anthro-socal.json** — `anthro-socal-2026` djs.opens → **2026-04-10** (add, conf 0.95)
> CALLING ALL DJs! Our #ASC2026 applications are slowly opening, starting with the DJ Applications! We'll be taking your apps & demos until June 4, 2026, so don't delay! We're going to make this year BUMPING with music. 🎧🎶 Apply here: anthrosocal.org/prog...
> — [source post](https://bsky.app/profile/anthrosocal.org/post/3mj5vo6drq22p) at 2026-04-10T18:00:23.000Z

**anthro-weekend-utah.json** — `anthro-weekend-utah-2026` djs.closes → **2026-04-17** (add, conf 0.9)
> [20260416-120011-AV] *SIRENS BLARING* Recruits! Application deadlines to perform as a DJ or for LollapAWUza are on the horizon! Get those applications in before its too late! Applications close tomorrow after 11:59 MDT
> — [source post](https://bsky.app/profile/anthroweekendutah.org/post/3mjmyhfzgfk2i) at 2026-04-16T18:00:15.163Z

**anthro-weekend-utah.json** — `anthro-weekend-utah-2026` djs.opens → **2026-03-16** (add, conf 0.9)
> [20260316-200502-AV] * AUDIO DETECTED * A deep rumble has been heard coming from within the trench, sounding like... a beat? DJ/LollapAWUza applications are now open until April 17th! All pilots willing to embark on this mission, whether solo or squadron, submit your applications on myawu.org!
> — [source post](https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t) at 2026-03-17T02:05:44.665Z

**anthro-weekend-utah.json** — `anthro-weekend-utah-2026` performances.opens → **2026-05-14** (add, conf 0.85)
> [20260514-130404-DANCE] * DO THE ROBOT * It's time to show off your dance moves! The #AWU2026 Fursuit Dance Competition is now open for sign-ups! Grab your mech suit and pop, lock, and strut your way to the prize! Sign up today on MyAWU myawu.org
> — [source post](https://bsky.app/profile/anthroweekendutah.org/post/3mltj4wdejs25) at 2026-05-14T19:04:58.458Z

**aurawra.json** — `aurawra-2026` performances.closes → **2026-07-10** (add, conf 0.8)
> Ever wondered why Aurawra hasn't had a dance competition until now? 🌟 Well wonder no more - from seasoned dancer professionals to first-timers, come write history at Aurawra's first ever dance competition! 🌟 🌸 Sign ups are now open! 🌸 https://awaw.au/FursCanDance Form closes July 10th!
> — [source post](https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a) at 2026-06-04T05:49:59.850Z

**awoostria.json** — `awoostria-2026` performances.opens → **2026-03-16** (add, conf 0.9)
> 📢 DJs & Dancers wanted! 🐾🎧 Applications for Awoostria’s DJ lineup and the Fursuit Dance Competition are now open! 🎧 DJ: awoostria.at/contribute/for… 🕺 FDC: awoostria.at/contribute/for��� Show us your beats or your moves! ✨🐺 📸: @cartooncoon.bsky.social
> — [source post](https://bsky.app/profile/awoostria.at/post/3mh72r2xa5s2o) at 2026-03-16T18:13:46.986Z

**awoostria.json** — `awoostria-2026` djs.opens → **2026-03-16** (add, conf 0.9)
> 📢 DJs & Dancers wanted! 🐾🎧 Applications for Awoostria’s DJ lineup and the Fursuit Dance Competition are now open! 🎧 DJ: awoostria.at/contribute/for… 🕺 FDC: awoostria.at/contribute/for��� Show us your beats or your moves! ✨🐺 📸: @cartooncoon.bsky.social
> — [source post](https://bsky.app/profile/awoostria.at/post/3mh72r2xa5s2o) at 2026-03-16T18:13:46.986Z

**awoostria.json** — `awoostria-2026` volunteers.opens → **2026-04-16** (add, conf 0.9)
> 🚨 We want YOU! 🚨 Be part of an amazing team that provides a safe and enjoyable experience for all attendees. No prior experience required, just a friendly attitude and willingness to assist! Just click below to apply! awoostria.at/open-positions (Video credit: @/cartooncoon)
> — [source post](https://bsky.app/profile/awoostria.at/post/3mjmqdyjmvs2z) at 2026-04-16T15:35:10.427Z

**barkada-furfest.json** — `barkada-furfest-2026` performances.opens → **2026-06-30** (add, conf 0.9)
> 🎤IT'S SHOWTIME! TALENT SHOW APPLICATIONS ARE OPEN! 🎤 What's a birthday without some top-tier entertainment? Whether you’re a singer, a dancer, a comedian, or have a unique party trick up your sleeve, we want to see you SHINE! Sign up for the Talent show here! forms.gle/ZVAe4rdVjzXK...
> — [source post](https://bsky.app/profile/barkadafurfest.bsky.social/post/3mpiva53zvc2a) at 2026-06-30T11:23:00.526Z

**biggest-little-fur-con.json** — `biggest-little-fur-con-2026` djs.closes → **2026-05-17** (add, conf 0.95)
> Attention Passengers The ocean waves are fun and all, but sound waves can really rock our boat. Apply to be one of our DJs today! goblfc.org/nightly-danc... Don't delay. The app is sailing away May 17th! #BLFC2026
> — [source post](https://bsky.app/profile/goblfc.org/post/3mloldwqaxs2y) at 2026-05-12T20:01:21.750Z

**brasil-furfest.json** — `brasil-furfest-2026` registration.opens → **2025-09-20** (add, conf 0.9)
> A Brasil FurFest 2026 – Sem Tempo, Irmão! vai abrir as vendas de ingressos neste domingo, às 21:00, durante a BFF Live, transmitida direto do Premium Hotel, em Campinas! 🦊🎉 ⏰ Marca no calendário: domingo, 20:00 a live – 21:00 o início das vendas! Não perca!
> — [source post](https://bsky.app/profile/brasilfurfest.bsky.social/post/3lza7jana7k2n) at 2025-09-20T01:18:50.188Z

**brasil-furfest.json** — `brasil-furfest-2026` djs.opens → **2026-05-12** (add, conf 0.8)
> 🎧 QUER SER DJ NA BRASIL FURFEST 2026? 🕺🐾 As baladas da BFF vão viajar no tempo! Sets temáticos com músicas dos anos 70, 80, 90, 2000 e muito mais! ⏰✨ Os DJs selecionados recebem entrada Fursona para o evento! 🔥 ⚠️ Vagas por curadoria 📋 Formulário + regras completas: forms.gle/Pn65YpmrgY67...
> — [source post](https://bsky.app/profile/brasilfurfest.bsky.social/post/3mln6ameot22b) at 2026-05-12T06:34:12.660Z

**calfurry.json** — `calfurry-2026` panels.opens → **2026-03-01** (amend 2026-02-28 -> 2026-03-01, conf 0.9)
> Step right up and show us what you've got! Programming submissions are now open for Calfurry 2026 - it's not first come, first serve, so take your time if you're figuring out what you want to do! What talents and sideshows will you grace the midway with? www.calfurry.ca/programming
> — [source post](https://bsky.app/profile/calfurry.ca/post/3mfze674wk42i) at 2026-03-01T18:21:00.951Z

**calfurry.json** — `calfurry-2026` performances.opens → **2026-02-28** (add, conf 0.9)
> Get excited! We're opening programming and performance submissions on February 28! What fun, wacky and entertaining acts do you plan to bring to the midway? We look forward to seeing what you submit!
> — [source post](https://bsky.app/profile/calfurry.ca/post/3mfmjudnsx22i) at 2026-02-24T15:58:15.915Z

**canfurence.json** — `canfurence-2026` panels.opens → **2026-01-15** (add, conf 0.95)
> Canfurence is looking for any experts of the seas and survival to give some suggestions and tips for any new drifters on the sea, come and share your knowledge with us! Panel applications are now open! Submit your panel ideas over here at forms.gle/4XukX3Zwa37y...
> — [source post](https://bsky.app/profile/canfurence.bsky.social/post/3mcilmghkyk2w) at 2026-01-15T22:03:24.418Z

**carolina-furfare.json** — `carolina-furfare-2026` djs.closes → **2026-07-12** (add, conf 0.9)
> The music is still out there, but not for long! DJ applications for CFF 2026 close in ONE WEEK! Don’t let your application become an unsolved mystery! All genres and styles are welcome! Applications close 11:59pm ET, July 12th so don’t delay! www.carolinafurfare.org/djs
> — [source post](https://bsky.app/profile/carolinafurfare.bsky.social/post/3mpybpej7ts2u) at 2026-07-06T14:16:12.594Z

**eufuria.json** — `eufuria-2026` performances.closes → **2026-07-08** (add, conf 1)
> Get your dance on at #Eufuria2026! 💃 You have exactly one month from today to submit your routines. Fursuit Dance Competition applications will close on July 8. 🕺 Rules and sign-up form: eufuria.org/dance-compet...
> — [source post](https://bsky.app/profile/eufuria.org/post/3mnrswazsqg2y) at 2026-06-08T13:45:15.998Z

**eurofurence.json** — `eurofurence-30` registration.opens → **2026-02-08** (add, conf 0.9)
> Ready for the Fantastic Furry Festival? Registration for #EF30 opens on 🎉 February 8th, 20:00 CET 🎉 Let's get this party started! Find all the info and more on our new website: www.eurofurence.org/EF30/ #Eurofurence 30 🗓 August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mddqnjlbwc2j) at 2026-01-26T17:15:22.873Z

**eurofurence.json** — `eurofurence-30` djs.opens → **2026-03-09** (add, conf 0.9)
> 🔊Turn up the beat!🎵 We are opening up the DJ applications. You think you got the right beats for the job? Then check out our form and prepare a small sample. Apply here: cloud.eurofurence.org/index.php/ap... #Eurofurence 30 🗓August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mgna2uldwc2v) at 2026-03-09T16:00:49.261Z

**eurofurence.json** — `eurofurence-30` djs.closes → **2026-05-31** (add, conf 0.9)
> 🔊PAWS IN THE AIR!🎵 Make the crowd party like never before and apply as a DJ at Eurofurence 30! The DJ applications will remain open until 31.05. cloud.eurofurence.org/index.php/ap... #Eurofurence 30 🗓August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mjrvabp77k2x) at 2026-04-18T16:45:53.219Z

**eurofurence.json** — `eurofurence-30` panels.opens → **2026-05-11** (amend 2026-04-03 -> 2026-05-11, conf 0.9)
> 📣 Got more to share? 🎨 There is still time to bring your creativity & ideas to #EF30! From meetups to creative group activities, your panel can bring even more joy to #EF30. Submit yours here: eurofurence.org/EF30/events #Eurofurence 30 🗓August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mlljzcdbk22g) at 2026-05-11T14:59:32.612Z

**eurofurence.json** — `eurofurence-30` performances.opens → **2026-04-06** (add, conf 0.9)
> The Floor is yours! Paws on Fire and Enter the Arena are looking for your moves to shake up 30 years of Eurofurence. Register now for #EF30 's dance competitions at: eurofurence.org/EF30/dancecontests #Eurofurence 30 🗓August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mitn37gitk2g) at 2026-04-06T16:00:00.866Z

**fluufff.json** — `fluufff-2026` volunteers.opens → **2026-06-21** (add, conf 0.9)
> Want to see the Fursuit Games happen? The Snack Exchange? Fursuit Charades? A big fancy fashion show? We could really use more helping paws to team up and realise these events! 🫵 Sign up now ➡️ fluufff.org/events youtube.com/shorts/thzfN...
> — [source post](https://bsky.app/profile/fluufffcon.bsky.social/post/3moscjy2ck42i) at 2026-06-21T11:49:55.422Z

**fluufff.json** — `fluufff-2026` djs.opens → **2026-06-07** (add, conf 0.95)
> 🎵Want to play your epic soundtrack or mix together some cool endgame music? Our DJ application form is up now! Sign up here➡️https://docs.google.com/forms/d/e/1FAIpQLSfkwY_1xpNTZrHqZMRphQhbrhw3lhhoogfOAePy9vXnSqxDIw/viewform Art by Scott (Do you recognize the reference?👀)
> — [source post](https://bsky.app/profile/fluufffcon.bsky.social/post/3mnp3tcqcr323) at 2026-06-07T11:46:41.582Z

**fur-eh.json** — `fur-eh-2026` performances.closes → **2026-06-30** (add, conf 0.9)
> 📆 Last day! 📆 The Fur-Eh! Dance Competition is looking for competitors ready to rock the revelry on the main stage, but applications close June 30! Hop to https://fureh.ca/dance to apply today! (And don't forget to get your media in by July 10! Our A/V team will appreciate it.) #FurEh #FEH2026
> — [source post](https://bsky.app/profile/fur-eh.bsky.social/post/3mpjs5wgjwj2d) at 2026-06-30T20:00:44.397035309Z

**furnavia.json** — `furnavia-2026` djs.opens → **2026-06-08** (add, conf 0.9)
> 📢 DJ Applications for Furnavia 2026 are now OPEN! 🎶 We are looking for DJs of all styles and genres to come and play at Furnavia! For more information on how to apply visit to our website: furnavia.org/apply 🎨: linktr.ee/xnirox
> — [source post](https://bsky.app/profile/furnavia.bsky.social/post/3mnrn6kwfts2g) at 2026-06-08T12:02:32.371Z

**furnavia.json** — `furnavia-2026` djs.closes → **2026-09-15** (add, conf 0.9)
> Want to play at Furnavia? We're in the hunt for DJs! 👀 All styles are welcome, whether you spin rock, house, DnB, ambient or anything in between! Applications open from June 8th to September 15th 2026, so mark your calendar! Want to go to Furnavia? Visit: furnavia.org
> — [source post](https://bsky.app/profile/furnavia.bsky.social/post/3mnnaah7fks2b) at 2026-06-06T18:00:17.983Z

**furnavia.json** — `furnavia-2026` volunteers.opens → **2026-06-26** (add, conf 0.8)
> We're is looking for volunteers! 🪄 Want to help making Furnavia even better? We've got a variety of departments you can be part of, including: 🎭 Events and Ceremony ✏️ Con-Ops 🦊 Fursuit Lounge 🛡️ Security 🩹 Medic 🎨 Art Show + more! More info at: furnavia.org/volunteer
> — [source post](https://bsky.app/profile/furnavia.bsky.social/post/3mp7d6ynhxc2n) at 2026-06-26T16:06:17.302Z

**furrest-city.json** — `furrest-city-2026` performances.opens → **2026-06-19** (add, conf 0.9)
> Ready to shake your tails? Dance comp signups are now open for Furrest City! Signups are open until Friday, September 18th! Please make sure to read the rules on our website for more information! furrestcity.org/dance-compet...
> — [source post](https://bsky.app/profile/furrestcity.org/post/3mom6rfbzls2w) at 2026-06-19T01:26:30.796Z

**furrest-city.json** — `furrest-city-2026` performances.closes → **2026-09-18** (add, conf 0.9)
> Ready to shake your tails? Dance comp signups are now open for Furrest City! Signups are open until Friday, September 18th! Please make sure to read the rules on our website for more information! furrestcity.org/dance-compet...
> — [source post](https://bsky.app/profile/furrestcity.org/post/3mom6rfbzls2w) at 2026-06-19T01:26:30.796Z

**furry-blacklight.json** — `furry-blacklight-2026` registration.opens → **2026-04-21** (amend 2026-04-18 -> 2026-04-21, conf 0.9)
> ✈️ Following yesterday’s announcement… The gates are now open 👀 You can officially join us and show your interest, the registration is now OPEN! ✨ See you onboard for #FBL14 🛫 📹️@potitcerf.bsky.social
> — [source post](https://bsky.app/profile/fblacklight.bsky.social/post/3mjzlnck3op23) at 2026-04-21T18:15:30.788Z

**furry-blacklight.json** — `furry-blacklight-2026` registration.opens → **2026-05-09** (amend 2026-04-21 -> 2026-05-09, conf 0.95)
> Dear passengers, Get ready ! ✈️ The registration for the convention pass only will open soon : today at 8PM (CEST) 🎟️ You can already create your account with this link : registration.fblacklight.org 📸 @chubbykirin.bsky.social
> — [source post](https://bsky.app/profile/fblacklight.bsky.social/post/3mlgchi36re24) at 2026-05-09T13:00:59.806Z

**furry-blacklight.json** — `furry-blacklight-2026` registration.opens → **2026-05-09** (update, conf 0.95)
> Boarding is now open ✈️ Convention passes for #FBL14 are officially available! 🐾 Get ready to join us for a brand new adventure above the clouds 🛫 📹️ @potitcerf.bsky.social
> — [source post](https://bsky.app/profile/fblacklight.bsky.social/post/3mlgtanjrzc2p) at 2026-05-09T18:01:24.249Z

**furry-migration.json** — `furry-migration-2026` djs.closes → **2026-07-11** (add, conf 0.9)
> Got some bomb jams and know how to keep the crowd moving? We're looking for DJs to perform and encourage those fantabulous dance moves. If you're interested in showing the crowd what you've got, DJ applications are open until July 11th! www.furrymigration.org/events/dances/
> — [source post](https://bsky.app/profile/furrymigration.org/post/3mo47s6dk6c2w) at 2026-06-12T17:02:14.978Z

**further-confusion.json** — `further-confusion-2027` djs.opens → **2026-05-21** (add, conf 0.95)
> Don't forget! @furcon.bsky.social DJ Applications are OPEN NOW until June 24th! furtherconfusion.org/programming/... #FC2027
> — [source post](https://bsky.app/profile/furcon.bsky.social/post/3mmentnmj7c2k) at 2026-05-21T14:44:31.609Z

**further-confusion.json** — `further-confusion-2027` djs.closes → **2026-06-24** (add, conf 0.95)
> Hey Friends! DJ Applications are OPEN NOW until June 24th! For more info, check out: furcon.org/programming/...
> — [source post](https://bsky.app/profile/furcon.bsky.social/post/3mmf7nq6q5m2f) at 2026-05-21T20:03:20.286Z

**further-confusion.json** — `further-confusion-2026` volunteers.opens → **2026-01-17** (add, conf 0.9)
> #FurCon2026 is run entirely by volunteers, and can always use more helping paws! For a minimum of 8 hours, receive benefits such as staff feed and comped Attendee registration! https://reg.furtherconfusion.org/apply/volunteer Full details: https://furtherconfusion.org/volunteer/
> — [source post](https://bsky.app/profile/furcon.bsky.social/post/3mcmzxtpqym24) at 2026-01-17T16:30:58.515Z

**furvester.json** — `furvester-7` dealers.closes → **2026-07-18** (add, conf 0.9)
> Mission Briefing // Dealers' Den Registration Agents: The wait is over. Dealers' Den registration is now open! To apply, submit your dossier through the registration form below. Applications will remain open until 18.07.2026. https://cloud.furvester.org/apps/forms/s/NL5nzQnbk8SmNfqNjo5PcYjw
> — [source post](https://bsky.app/profile/furvester.org/post/3mptncxdivl2r) at 2026-07-04T18:00:42.097Z

**futrolajki.json** — `futrolajki-2026` djs.opens → **2026-06-30** (add, conf 0.95)
> 🇵🇱 Zostań Jedi Mixu na Futrołajkach 2026! Masz Moc w palcach i sety potężniejsze niż Yoda? Chciałbyś rozkręcić parkiet tak, żeby nawet szturmowcy trafiali w rytm? Nie zwlekaj jak Obi-Wan na Tatooine - wyślij zgłoszenie i zostań DJ'em Futrołajek! Zgłoś się tutaj: events.foxcons.pl/fl26djs
> — [source post](https://bsky.app/profile/futrolajki.pl/post/3mpjluz2uv224) at 2026-06-30T18:08:23.260Z

**gateway-furmeet.json** — `gateway-furmeet-2026` dealers.opens → **2026-01-02** (add, conf 0.8)
> Good afternoon everyone, Registration for GFM 2026 is live! Dealers den applications, panel submissions, DJ applications, and more are also available on our website www.gatewayfurmeet.org
> — [source post](https://bsky.app/profile/gatewayfurmeet.org/post/3mbhi2llkh22p) at 2026-01-02T18:01:53.221Z

**gateway-furmeet.json** — `gateway-furmeet-2026` performances.opens → **2026-03-04** (add, conf 0.85)
> Put on your birthday best and get your groove on in the 🪩dance competition🪩! Sign ups are now open and can be found here -> https://www.gatewayfurmeet.org/dance-comp (and please leave the confetti at home 🫣)
> — [source post](https://bsky.app/profile/gatewayfurmeet.org/post/3mgaxrh6yn42c) at 2026-03-04T19:00:26.436312+00:00

**gateway-furmeet.json** — `gateway-furmeet-2026` performances.opens → **2026-05-14** (amend 2026-03-04 -> 2026-05-14, conf 0.85)
> Think you’ve got the best moves? 🐾✨ Step out and face off against fellow dancers in the 🔥Cardinal Clash🔥 Signups are open now: https://www.gatewayfurmeet.org/cardinalclash
> — [source post](https://bsky.app/profile/gatewayfurmeet.org/post/3mlrj6phvch2h) at 2026-05-14T00:00:38.875376+00:00

**gateway-furmeet.json** — `gateway-furmeet-2026` djs.opens → **2026-01-28** (add, conf 0.85)
> Giraffic design is my passion✨ What's an epic party without some amazing music? DJ applications for our nightly dances are open and can be found here www.gatewayfurmeet.org/dances
> — [source post](https://bsky.app/profile/gatewayfurmeet.org/post/3mdixmon4hk24) at 2026-01-28T19:03:29.516Z

**goldenhorn.json** — `goldenhorn-2026` djs.opens → **2026-05-19** (add, conf 0.9)
> 🚨 GOLDENHORN IS LOOKING FOR DJs! 🚨 We are searching for DJs who can electrify our dance floor and elevate the atmosphere through the roof! Whether you’re a pro or a hobbyist, we invite you to apply! Sign up from the link below to apply today! goldenhorn.si/dj
> — [source post](https://bsky.app/profile/goldenhorn.si/post/3mm7ntzbgy22h) at 2026-05-19T15:01:25.104Z

**indonesia-weekend-anthro-gathering.json** — `indonesia-weekend-anthro-gathering-2026` registration.opens → **2026-07-03** (amend 2026-01-03 -> 2026-07-03, conf 0.9)
> IWAG 2026 Pre-Registration opens Friday, 3 July 2026 from 21:00 to 22:30. This is available for all Architect, Overseer Cipher tiers, Dealers, Performers and Panelists. Beginning 20:45, proceed to the Hotel Lobby to retrieve your Pre-Reg Group card. First come first serve.
> — [source post](https://bsky.app/profile/iwag.furries.id/post/3mpq7rgevqc27) at 2026-07-03T09:20:16.269Z

**indonesia-weekend-anthro-gathering.json** — `indonesia-weekend-anthro-gathering-2026` djs.opens → **2026-02-05** (add, conf 0.9)
> ATTENTION PARTY ANIMALS OF MEGAPOLIS!! DJ applications for IWAG 2026 are now open! The night belongs to you. The only question is... do you have the guts to rule the stage? Tune in and transmit your submission before 12 April, 2026, 23:59 UTC+7 (16:59 UTC).
> — [source post](https://bsky.app/profile/iwag.furries.id/post/3me4h5lu72k2p) at 2026-02-05T13:01:58.186Z

**indonesia-weekend-anthro-gathering.json** — `indonesia-weekend-anthro-gathering-2026` volunteers.opens → **2026-01-24** (add, conf 0.9)
> Meowdy Critters!! IWAG is looking for talented volunteers to join our team so we can create a magical moment together. We have numerous open positions available that can suit your interest or skill.
> — [source post](https://bsky.app/profile/iwag.furries.id/post/3md5zx7deak2t) at 2026-01-24T10:45:52.926Z

**indonesia-weekend-anthro-gathering.json** — `indonesia-weekend-anthro-gathering-2026` djs.closes → **2026-04-12** (add, conf 0.9)
> Panel & Activity, Volunteer and DJ Application closes tomorrow, 12 April at 23:59 UTC+7! And by the way - here's the deadlines for all applications. There's still a day left to put your applications in, so if you're interested - it's time to hammer those in! Check deets below 👇
> — [source post](https://bsky.app/profile/iwag.furries.id/post/3mj7tlzqorc2m) at 2026-04-11T12:28:44.770Z

**indyfurcon.json** — `indyfurcon-2026` performances.opens → **2026-05-15** (add, conf 0.9)
> IndyFurCon Dancers... 💃🕺 The Sign-Ups for the Dance Competition and FloorWarz for #iFC2026 are OPEN! Please see the respective forms below, and get your dancin' shoes ready! 🪩 🕺 Dance Comp Sign-Up: https://forms.gle/Vcn7Q6u6MeESp1bB6 🔥 FloorWarz Sign-Up: https://forms.gle/dbv66Vuiu5uRdUXQ6
> — [source post](https://bsky.app/profile/indyfurcon.org/post/3mlvm4osnqc2x) at 2026-05-15T15:03:51.046596Z

**indyfurcon.json** — `indyfurcon-2026` djs.closes → **2026-04-01** (add, conf 0.9)
> Prospective DJs and Applicants! The #iFC2026 DJ Application will be closing TOMORROW! Make sure to get your mixes finalized and apply soon! ⏰ Submissions close Tomorrow, April 1st 🎧 DJ Application: https://forms.gle/BCFNZFkYa4vtaWGF6 📸 Ocebot / 🐱 Riley Winters
> — [source post](https://bsky.app/profile/indyfurcon.org/post/3miedunyalm2y) at 2026-03-31T14:05:21.368827Z

**infurnity.json** — `infurnity-2026` performances.closes → **2026-09-01** (add, conf 0.9)
> 【 #INFURNITY2026 | Transmission】 …The wasteland stage roars with fire... Stage access authorized Survivors ready to take the stage are welcome Awaiting your signal ⏳ Deadline: 09 / 01 ✨ www.infurnity.com/en/2026/07/s... 📡 Official updates: t.me/infurnity 【END TRANSMISSION】
> — [source post](https://bsky.app/profile/infurnity.bsky.social/post/3mpvks42k4k2a) at 2026-07-05T12:20:48.850Z

**infurnity.json** — `infurnity-2026` djs.closes → **2026-08-01** (add, conf 0.9)
> 【 #INFURNITY2026 | Transmission】 Shelter night channel coming online Requesting furry bands and DJs to help maintain the audio transmission system ⏳ Deadline: 08 / 01 🎸 www.infurnity.com/en/band-en/ 💿 www.infurnity.com/en/dj-en/ 📡 Official updates: t.me/infurnity 【END TRANSMISSION】
> — [source post](https://bsky.app/profile/infurnity.bsky.social/post/3mpsokj5goc2k) at 2026-07-04T08:50:09.893Z

**infurnity.json** — `infurnity-2026` hotel.closes → **2026-05-25** (add, conf 0.9)
> 【 #INFURNITY2026 | TRANSMISSION】 Main hotel lottery results can be viewed in your email inbox or registration system. Reservation links processed by the hotel will be sent out no later than this Friday. Deadline for main hotel reservations: 5/25.
> — [source post](https://bsky.app/profile/infurnity.bsky.social/post/3mmbn366lys2w) at 2026-05-20T09:52:50.903Z

**nordicfuzzcon.json** — `nordicfuzzcon-2026` volunteers.opens → **2026-01-12** (add, conf 0.85)
> The show must go on and we could use more paws! 🐾 Become a #NFC2026 volunteer and join SOUP to get cool rewards! Help make Cirque du Nord a magical experience. To read more, visit the SOUP page. nfuzz.co/soup Ready to join and go through all 20 levels? Join the SOUP Den. nfuzz.co/soup-den 🎨 Arty
> — [source post](https://bsky.app/profile/nordicfuzzcon.org/post/3mcau5qmihk27) at 2026-01-12T20:14:57.514Z

**pawai.json** — `pawai-2026` performances.opens → **2026-05-08** (add, conf 0.8)
> PAWAI 2026 Talent Show Auditions are OPEN! Bring your energy! Solo/group, fursuit/non-suit welcome. Max 5 mins, open theme! Audition closes on July 31, 2026 forms.gle/hSngwcoxLDc2... Break a leg, Fuzzies! ♥️☀️⛱
> — [source post](https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e) at 2026-05-08T11:00:42.729Z

**pawai.json** — `pawai-2026` performances.closes → **2026-07-31** (add, conf 0.8)
> PAWAI 2026 Talent Show Auditions are OPEN! Bring your energy! Solo/group, fursuit/non-suit welcome. Max 5 mins, open theme! Audition closes on July 31, 2026 forms.gle/hSngwcoxLDc2... Break a leg, Fuzzies! ♥️☀️⛱
> — [source post](https://bsky.app/profile/pawaiid.bsky.social/post/3mldlbhtwjs2e) at 2026-05-08T11:00:42.729Z

**pawcon.json** — `pawcon-2026` performances.opens → **2026-05-08** (add, conf 0.9)
> ATTENTION ALL TEST SUBJECTS, LAB RATS, and MAD SCIENTISTS: Panels, Performers, and Party Floor Submissions are now open! Present your research, demonstrate your talents, or volunteer to host a controlled social experiment. pacanthro.org/panels/ pacanthro.org/events/ pacanthro.org/party-floor/
> — [source post](https://bsky.app/profile/pawcon.bsky.social/post/3mleavvmtxk26) at 2026-05-08T17:27:56.847Z

**pawsome.json** — `pawsome-2026` djs.opens → **2026-04-17** (add, conf 0.9)
> Drop some filthy beats for us! DJ applications for Pawsome are now open! forms.cloud.microsoft/e/k5wCwG8QEm Applications close Sunday 7th June.
> — [source post](https://bsky.app/profile/pawsome.bsky.social/post/3mjphay5zcv2g) at 2026-04-17T17:30:23.503Z

**pawsome.json** — `pawsome-2026` djs.closes → **2026-06-07** (add, conf 0.9)
> Not long left to apply to DJ at Pawsome 2026! DJ Applications close on Sunday 7th June! Apply here: forms.cloud.microsoft/e/k5wCwG8QEm
> — [source post](https://bsky.app/profile/pawsome.bsky.social/post/3mnao655kv32o) at 2026-06-01T18:04:56.100Z

**stratosfur.json** — `stratosfur-2026` panels.closes → **2026-06-24** (add, conf 0.9)
> Panel Applications are NOW OPEN!!! If you want to gather as many canine's in one room, or want run a game show, or have an art jam, send in your application. Applications will close June 24th at 11:59PM central time. Go to stratosfur.org/schedule to apply
> — [source post](https://bsky.app/profile/stratosfur.org/post/3mgy5avem7v2v) at 2026-03-14T00:09:47.136058Z

**stratosfur.json** — `stratosfur-2026` djs.opens → **2026-02-11** (add, conf 0.9)
> DJ Applications are now OPEN! Visit stratosfur.org/dj to find the form to apply. As a reminder, DJ's that are selected will be given a free registration voucher.
> — [source post](https://bsky.app/profile/stratosfur.org/post/3mem2or4fmx25) at 2026-02-11T18:01:30.972540Z

**stratosfur.json** — `stratosfur-2026` djs.closes → **2026-04-30** (add, conf 0.9)
> Everyone, we have our DJ applications open. The application will close April 30th at 11:59pm central time. There is still time to get your application in but don't wait too long. Go to stratosfur.org/dj to find the application
> — [source post](https://bsky.app/profile/stratosfur.org/post/3mijqcz5v6d2k) at 2026-04-02T17:31:26.497297Z

**stratosfur.json** — `stratosfur-2026` performances.opens → **2026-05-08** (add, conf 0.9)
> Everyone, We have dance comp sign ups open. Apply for Stratosfur's dance competition at stratosfur.org/dance-compet...
> — [source post](https://bsky.app/profile/stratosfur.org/post/3mletld5ecc25) at 2026-05-08T23:02:02.799166Z

**stratosfur.json** — `stratosfur-2026` volunteers.opens → **2026-06-11** (add, conf 0.8)
> Everyone, we are looking for more staff. There are openings in several departments. Go to stratosfur.org/volunteer to apply. We needs paws for departments like video games, table top, dealers, etc. Our volunteer application is on the same page if you can only help a few hours.
> — [source post](https://bsky.app/profile/stratosfur.org/post/3mo2ezv2eix2d) at 2026-06-11T23:30:42.724204Z

**stratosfur.json** — `stratosfur-2026` registration.opens → **2026-02-10** (add, conf 0.95)
> Registrations News! We will be opening pre-reg tomorrow 02/10/2026 at 8pm central time. Room block will open soon and we will have news for that soon also.
> — [source post](https://bsky.app/profile/stratosfur.org/post/3meht4mvwec2k) at 2026-02-10T01:35:27.540709Z

**tails-and-tornadoes-fur-con.json** — `tails-and-tornadoes-fur-con-2026` panels.opens → **2026-04-28** (add, conf 0.9)
> It’s time to build that panel schedule! Have a panel you would like to host? Submit it today! Panel submissions will be open thru July 1! Visit: tailsandtornadoes.org/panels #ttfc2026 🦖 🚘 🎶
> — [source post](https://bsky.app/profile/tailsandtornadoes.org/post/3mkknfyqtee24) at 2026-04-28T13:02:28.674Z

**tails-and-tornadoes-fur-con.json** — `tails-and-tornadoes-fur-con-2026` performances.opens → **2026-05-09** (add, conf 0.9)
> Ready to dance your heart out in front of TTFC on our dance floor? Dance Competition signups are now open! Check it out! tailsandtornadoes.org/dance-comp/
> — [source post](https://bsky.app/profile/tailsandtornadoes.org/post/3mlh4t5lnh223) at 2026-05-09T20:52:47.536Z

**tails-of-summer.json** — `tails-of-summer-2026` dealers.closes → **2026-06-30** (add, conf 0.8)
> Attention Artist Alley Applicants: Be sure to check your email (junk mail included) and for those interested, the application is still open until June 30th! tailsofsummer.com/artist-alley/
> — [source post](https://bsky.app/profile/tailsofsummer.com/post/3mmrxdz3k7k2l) at 2026-05-26T21:39:20.782Z

**tails-of-summer.json** — `tails-of-summer-2026` djs.closes → **2026-06-10** (add, conf 0.9)
> DJ applications have been EXTENDED until JUNE 10! Make sure you get your application in to rock the dance floor at Tails of Summer 2026! Details are on our website: tailsofsummer.com/djapps/
> — [source post](https://bsky.app/profile/tailsofsummer.com/post/3mng4appn4h2y) at 2026-06-03T22:00:12.304Z

**tails-of-summer.json** — `tails-of-summer-2026` panels.opens → **2026-06-01** (add, conf 0.9)
> We're still looking for PANELS, particularly meetups! Do you have an interest? a species? Run a social meetup panel about your species or interest! Run a Cat or canine meetup, a fandom meetup, maybe something spicier? Submit yours now! tailsofsummer.com/panels-submi... #furrycon #panels
> — [source post](https://bsky.app/profile/tailsofsummer.com/post/3mnako4mstk2y) at 2026-06-01T17:02:17.300Z

**tails-of-terror.json** — `tails-of-terror-2026` performances.opens → **2026-05-13** (add, conf 0.9)
> Performer applications are OPEN! 🎃 Join the chaos at Tails of Terror 2026 👀 👉🏻 forms.cloud.microsoft/Pages/Respon... Closes 15/06/2026 - don’t miss out!
> — [source post](https://bsky.app/profile/furdu.com.au/post/3mlpyskuxk224) at 2026-05-13T09:34:51.837Z

**tails-of-terror.json** — `tails-of-terror-2026` performances.closes → **2026-06-15** (add, conf 0.9)
> Performer applications are OPEN! 🎃 Join the chaos at Tails of Terror 2026 👀 👉🏻 forms.cloud.microsoft/Pages/Respon... Closes 15/06/2026 - don’t miss out!
> — [source post](https://bsky.app/profile/furdu.com.au/post/3mlpyskuxk224) at 2026-05-13T09:34:51.837Z

**western-pa-furry-weekend.json** — `western-pa-furry-weekend-2026` registration.opens → **2026-06-06** (amend 2026-06-05 -> 2026-06-06, conf 0.95)
> ATTENTION! Registration is now open for WPAFW 2026! Follow the link below to get registered - we can't wait to see you in October! reg.wpafw.org
> — [source post](https://bsky.app/profile/wpafw.bsky.social/post/3mnlk3u5bek2h) at 2026-06-06T01:51:21.714Z

### Refuted by verification (not applied)
- `alamo-city-furry-invasion-2026` djs.opens 2026-02-01 — The post states that applications for Dealer's Den and Artist Alley are open, which aligns with the dealers category, but there is no mention of DJ set applicat
- `alamo-city-furry-invasion-2026` performances.opens 2026-05-15 — The post states that signups for the Tails and Taillights car show are now open. It describes a car show with proceeds to charity, but unless it is a talent/var
- `anthro-socal-2026` djs.closes 2026-06-04 — The post mentions June 4 as the estimated closing date but does not explicitly confirm the exact time or date of closure.
- `anthro-socal-2026` performances.closes 2026-07-25 — The post refers to applications for PARTY FLOOR & NOISY BLOCK, related to parties and hosting, not dance competition, talent/variety show, or performer audition
- `anthro-weekend-utah-2026` dealers.closes 2026-02-13 — The post text states dealers' applications CLOSE SOON and gives a relative deadline ('by tomorrow at midnight'), but does not give the explicit date. Strict cri
- `anthro-weekend-utah-2026` hotel.opens 2026-03-20 — The post refers to the opening of the "Alpha/Dealer Hotel lottery" not general attendee hotel booking. Per category definitions, event-suite lotteries do not co
- `anthro-weekend-utah-2026` hotel.closes 2026-03-27 — The post refers to the closing of the Alpha/Dealer hotel lottery, which is not the general hotel block. This does not fall under the strict hotel category defin
- `anthrocon-2026` registration.closes 2026-07-03 — The post states that full weekend badges have sold out and that only day passes are available while supplies last. It does not indicate a true registration clos
- `aquatifur-2026` dealers.opens 2025-06-15 — source post (2025-06-15) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` volunteers.opens 2025-07-28 — source post (2025-07-28) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` panels.closes 2025-08-10 — source post (2025-08-10) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` djs.closes 2025-08-10 — source post (2025-08-10) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` djs.opens 2025-07-05 — source post (2025-07-03) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` panels.opens 2025-07-05 — source post (2025-07-03) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` performances.opens 2025-08-24 — source post (2025-08-24) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` performances.closes 2025-11-01 — source post (2025-08-24) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` registration.closes 2025-10-31 — source post (2025-10-17) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` hotel.opens 2025-07-01 — source post (2025-07-01) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aurawra-2026` performances.closes 2026-07-10 — The post concerns badge personalisation and sticker customisation, not performance signups or auditions. It makes no mention of performance applications closing
- `aurawra-2026` performances.opens 2026-07-10 — The post states that sign ups are "now open", meaning applications for performances opened prior to the post date (June 4th). The claim is about signups opening
- `aurawra-2026` registration.opens 2026-05-27 — The post announces that 'Prefill for Round 2 is now open,' but clarifies that prefill is not registration, and you must return 'during the opening to claim your
- `aurawra-2026` registration.opens 2026-05-27 — The post states that 'Prefill opens tonight at 7pm,' but is clear that prefill is not registration, and that standard registration opens 'this Friday at 7:15pm'
- `awoostria-2026` hotel.opens 2024-12-13 — source post (2024-12-13) predates the previous edition's end (2025-07-27) — almost certainly refers to an earlier edition
- `barkada-furfest-2026` dealers.closes 2026-07-01 — The stated closing is for the Dealer's Den 'confirmation form,' which applies only to already-accepted applicants needing to confirm their participation. This i
- `biggest-little-fur-con-2026` volunteers.opens 2026-05-14 — The post on May 14, 2026 says "Join our ship's crew" and links to a volunteer page, but it does not explicitly state that volunteer applications open on this da
- `brasil-furfest-2026` registration.closes 2025-09-22 — The post mentions ticket sales in the 'first lot' (primeiro lote) are available until 21/10. There is no mention of registration closing on 2025-09-22, just tha
- `brasil-furfest-2026` hotel.opens 2025-09-17 — The post refers to hotel room booking options related to Brasil FurFest 2026 but does not explicitly state the opening of the main convention's hotel room block
- `brasil-furfest-2026` registration.opens 2026-05-04 — The post encourages attendees to buy tickets ('GARANTA JÁ SEU INGRESSO') and gives the sales link, but there is no explicit statement about ticket sales opening
- `calfurry-2026` djs.closes 2026-07-05 — The post explicitly states that DJ applications are open until August 2. The claim that applications close July 5 is refuted because the true close date is Augu
- `calfurry-2026` volunteers.opens 2026-04-29 — The post states that volunteer applications for Calfurry 2026 open on May 1, but the claimed date is April 29. While the post was published on April 29, it expl
- `carolina-furfare-2026` dealers.opens 2026-05-16 — Post states 'The Artist Alley application has opened its gates!' on May 12, but does NOT specify the opening date as May 16. There is no explicit statement of t
- `carolina-furfare-2026` dealers.opens 2026-05-17 — Dealer-related application opening is only for Artist Alley, not both Artist Alley and Dealers Den.
- `confuror-2026` dealers.opens 2026-04-01 — The post states that vendor applications (Dealers Den, Night Market, Artist Alley) will open in April for Confuror 2026, but does not cite an explicit date of A
- `confuror-2026` dealers.opens 2026-07-01 — The post from July 1, 2026, is inviting already-selected (i.e., accepted) vendors for Confuror 2026 to join a promotional group, not announcing the opening of d
- `eurofurence-30` registration.closes 2026-03-22 — Post refers ONLY to Dealers' Den and Art Show registration closing on 22.03, not general attendee registration. By category definition, this is NOT registration
- `eurofurence-30` panels.closes 2026-06-19 — Post refers to sending art for a conbook by June 19th, not panel/programming proposals, and explicitly says 'art' and 'short stories.' By strict definition, thi
- `eurofurence-30` panels.closes 2026-06-19 — Post refers to submitting artwork, filler pictures, and short stories for the conbook by June 19, not panel submissions. This is conbook art/literature, not pan
- `eurofurence-30` performances.closes 2026-05-14 — The post states that registrations for dance competitions close on June 14, 2026, while the claim suggests May 14, 2026. The provided closing date does not matc
- `fur-eh-2026` djs.closes 2026-06-28 — Post refers to 'open-door parties' and 'room parties' applications, not DJ set applications as per strict DJ category definition. This is not a DJ set applicati
- `fur-eh-2026` djs.closes 2026-06-28 — Post refers to 'Party Block' and 'open-door parties', not DJ set applications as per strict DJ category definition. This is not a DJ set application deadline.
- `fur-eh-2026` djs.closes 2026-06-28 — Post refers to party room applications, not DJ set applications as per strict DJ category definition. This is not a DJ set application deadline.
- `fur-eh-2026` performances.closes 2026-06-20 — The post concerns a specific competition unrelated to the defined category of performances for dance or talent shows.
- `fureast-2026` registration.closes 2026-07-08 — The post refers to t-shirt & hoodie collection preorders closing on July 8, not general attendee badge or membership registration. This is not a registration cl
- `furlingame-2027` hotel.closes 2026-03-31 — source post (2026-03-23) predates the previous edition's end (2026-04-05) — almost certainly refers to an earlier edition
- `furlingame-2027` djs.closes 2026-02-20 — source post (2026-02-19) predates the previous edition's end (2026-04-05) — almost certainly refers to an earlier edition
- `furry-blacklight-2026` registration.opens 2026-04-28 — The claim states registration opened on April 28, 2026, but the post is tagged for #FBL14 yet dated in 2026, after the convention's conclusion. This suggests it
- `furry-migration-2026` volunteers.opens 2026-02-28 — The post refers to a 'job fair' to learn about volunteer opportunities but does not state that general volunteer signups for the convention open on this date. I
- `furry-weekend-atlanta-2027` registration.closes 2026-07-31 — The post states that 'Presale pricing ends July 31st @ 11:59PM,' which is a price change (end of presale pricing), not a hard close of registration. It does not
- `furrydelphia-2026` hotel.opens 2026-05-08 — The post explicitly states that hotel bookings will now open on May 15th, not May 8th. Therefore, the claim that hotel bookings open on May 8th is refuted.
- `fursonacon-2026` hotel.opens 2025-04-07 — source post (2025-04-07) predates the previous edition's end (2025-08-31) — almost certainly refers to an earlier edition
- `fursonacon-2026` panels.closes 2025-06-15 — source post (2025-06-13) predates the previous edition's end (2025-08-31) — almost certainly refers to an earlier edition
- `fursonacon-2026` dealers.opens 2025-02-01 — source post (2025-02-01) predates the previous edition's end (2025-08-31) — almost certainly refers to an earlier edition
- `futrolajki-2026` hotel.opens 2026-06-15 — The post text is a reminder for the opening of room booking on June 15 but does not announce the booking explicitly. Refuted.
- `futrolajki-2026` hotel.opens 2026-06-09 — The post does not confirm that hotel bookings open on 2026-06-09. It states that supersponsors' room reservations open at '15.06 8:00 p.m.' and for everyone at 
- `gateway-furmeet-2026` volunteers.opens 2026-02-04 — The post invites people to check out volunteering perks but does not explicitly state that volunteer signups are open. It is an informational post about perks, 
- `golden-leaves-con-16` registration.opens 2025-07-06 — source post (2025-07-06) predates the previous edition's end (2025-11-02) — almost certainly refers to an earlier edition
- `indyfurcon-2026` registration.closes 2026-06-28 — The post is about Epic Tier Registration closing June 28th, but this is a sponsor/upgrade badge and not general attendee registration. Per strict definitions, r
- `infurnity-2026` hotel.closes 2026-05-14 — The post specifies that the hotel lottery closes on 5/14, but hotel lottery does not count as the final hotel booking closing date or standard room block close.
- `infurnity-2026` hotel.opens 2026-05-01 — The post clearly states that the hotel lottery entry opened on 05/01, but as this is a lottery and pertains to entry eligibility rather than standard hotel book
- `noctfurnal-2026` registration.closes 2026-04-30 — The post only mentions an early bird pricing end. Per category definition, price-tier changes are NOT registration closes (which require a badge sales hard-clos
- `noctfurnal-2026` dealers.closes 2026-05-27 — The post states that dealers and performer slots are 'fully booked,' but it does not explicitly provide a close date for the applications period. Therefore, thi
- `nordicfuzzcon-2026` performances.closes 2026-01-15 — The post describes a deadline for signing up to be a GM (game master) for a 'storytelling tent' (TTRPG event). This is a panel/workshop/activity submission and 
- `pawcon-2026` volunteers.opens 2026-05-08 — The post text mentions panels, performers, and party floor submissions opening, but does NOT mention anything about general volunteer/staff signups. "Volunteer 
- `pawcon-2026` dealers.closes 2026-06-02 — The post text says the Artist Alley lottery is open and will accept applications until July 31st. The claim states dealers applications close June 2, but the ex
- `pawsome-2026` registration.closes 2026-04-25 — The post discusses a deadline for signing up for the room lottery, not the closing of general attendee registration. It explicitly states that non-residential t
- `slofluffcon-2027` registration.opens 2025-06-22 — source post (2025-06-22) predates the previous edition's end (2026-01-25) — almost certainly refers to an earlier edition
- `tails-of-summer-2026` volunteers.opens 2026-06-30 — The post text discusses specific calls for volunteers related to certain roles and provides a link to apply, indicating that volunteer signups were open by this
- `tails-of-summer-2026` dealers.closes 2026-06-30 — The post refers to 'Party Floor room' applications, which are for hosting parties and hotel event suites, not dealers or artist alley applications per the categ
- `tails-of-summer-2026` djs.closes 2026-06-10 — The post says 'LAST DAY FOR #DJ Apps' and lists June 9, but since the post is made on June 9 and applications are due, this likely refers to closing June 9, not
- `woods-flock-2027` registration.opens 2025-12-01 — source post (2025-12-01) predates the previous edition's end (2026-04-13) — almost certainly refers to an earlier edition