### PR TITLE
Add JMoF Bluesky account

### DIFF
--- a/japan-meeting-of-furries.json
+++ b/japan-meeting-of-furries.json
@@ -1,5 +1,9 @@
 {
   "name": "Japan Meeting of Furries",
+  "bluesky": {
+    "did": "did:plc:umwjtg42a4hn6ywn36rg72po",
+    "handle": "jmof-pr.bsky.social"
+  },
   "events": [
     {
       "id": "japan-meeting-of-furries-2027",


### PR DESCRIPTION
Registers the official Japan Meeting of Furries Bluesky account (`jmof-pr.bsky.social`, `did:plc:umwjtg42a4hn6ywn36rg72po`) at the series level so key-date sweeps and the automated importer can pick it up.

No `keyDates` added: the account currently has only 2 posts (both 2026-06-20 announcing the JMoF Archive) and carries no lead-up deadlines. Worth re-sweeping once they post reg/hotel windows for JMoF 2027.