### PR TITLE
Key dates from Bluesky (manual sweep 2026-07-07)

### DIFF
--- a/alamo-city-furry-invasion.json
+++ b/alamo-city-furry-invasion.json
@@ -44,9 +44,9 @@
           },
           "closes": {
             "date": "2026-02-18",
-            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mdsvyszkfc2o",
-            "asOf": "2026-02-01T18:01:06.660Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3meynsru5d22y",
+            "asOf": "2026-02-16T18:15:44.230Z",
+            "confidence": 0.9
           }
         },
         "panels": {
@@ -72,6 +72,12 @@
           }
         },
         "djs": {
+          "opens": {
+            "date": "2026-04-06",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mitqjwomtc2y",
+            "asOf": "2026-04-06T17:01:56.353Z",
+            "confidence": 0.8
+          },
           "closes": {
             "date": "2026-07-01",
             "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mn3jnkakk224",

--- a/anthro-irish.json
+++ b/anthro-irish.json
@@ -48,6 +48,12 @@
           }
         },
         "performances": {
+          "opens": {
+            "date": "2026-05-07",
+            "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",
+            "asOf": "2026-05-07T18:06:59.029Z",
+            "confidence": 0.8
+          },
           "closes": {
             "date": "2026-06-04",
             "source": "https://bsky.app/profile/anthro.irish/post/3mlbsmruy6k24",

--- a/anthro-new-england.json
+++ b/anthro-new-england.json
@@ -30,9 +30,9 @@
         "dealers": {
           "opens": {
             "date": "2026-07-01",
-            "source": "https://bsky.app/profile/ane.boston/post/3mpk2jbri3e2x",
-            "asOf": "2026-06-30T22:30:15.848Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/ane.boston/post/3mplv7ed4u32g",
+            "asOf": "2026-07-01T16:00:33.727Z",
+            "confidence": 0.85
           },
           "closes": {
             "date": "2026-07-31",

--- a/anthro-socal.json
+++ b/anthro-socal.json
@@ -30,9 +30,9 @@
         "hotel": {
           "opens": {
             "date": "2026-05-30",
-            "source": "https://bsky.app/profile/anthrosocal.org/post/3mmkc3dev4j2x",
-            "asOf": "2026-05-23T20:30:01.000Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mn3vki5lf22w",
+            "asOf": "2026-05-30T20:33:47.804Z",
+            "confidence": 0.8
           }
         },
         "dealers": {
@@ -83,6 +83,12 @@
             "source": "https://bsky.app/profile/anthrosocal.org/post/3mj5vo6drq22p",
             "asOf": "2026-04-10T18:00:23.000Z",
             "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-06-04",
+            "source": "https://bsky.app/profile/anthrosocal.org/post/3mj5vo6drq22p",
+            "asOf": "2026-04-10T18:00:23.000Z",
+            "confidence": 0.85
           }
         }
       }

--- a/awoostria.json
+++ b/awoostria.json
@@ -22,8 +22,8 @@
         "registration": {
           "opens": {
             "date": "2025-11-15",
-            "source": "https://bsky.app/profile/awoostria.at/post/3m47e6goekk2o",
-            "asOf": "2025-10-27T21:25:11.274Z",
+            "source": "https://bsky.app/profile/awoostria.at/post/3m5ot6hpt7c2f",
+            "asOf": "2025-11-15T18:28:46.202Z",
             "confidence": 0.85
           },
           "closes": {

--- a/big-sky-camp-paw.json
+++ b/big-sky-camp-paw.json
@@ -49,6 +49,20 @@
             "asOf": "2026-04-25T18:35:37.705Z",
             "confidence": 0.9
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-04-25",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mkdomxepkk2a",
+            "asOf": "2026-04-25T18:35:37.705Z",
+            "confidence": 0.8
+          },
+          "closes": {
+            "date": "2026-06-25",
+            "source": "https://bsky.app/profile/camppaw.org/post/3mkdomxepkk2a",
+            "asOf": "2026-04-25T18:35:37.705Z",
+            "confidence": 0.85
+          }
         }
       }
     },

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -30,9 +30,9 @@
         "hotel": {
           "opens": {
             "date": "2026-07-08",
-            "source": "https://bsky.app/profile/goblfc.org/post/3mnfsgvfbny2a",
-            "asOf": "2026-06-03T19:04:43.615Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/goblfc.org/post/3mpyydjwjyg2t",
+            "asOf": "2026-07-06T21:01:11.033Z",
+            "confidence": 0.85
           }
         },
         "dealers": {

--- a/calfurry.json
+++ b/calfurry.json
@@ -50,9 +50,9 @@
           },
           "closes": {
             "date": "2026-07-24",
-            "source": "https://bsky.app/profile/calfurry.ca/post/3moxntbl4nc2w",
-            "asOf": "2026-06-23T14:55:17.265Z",
-            "confidence": 0.93
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mprkb7rftn2i",
+            "asOf": "2026-07-03T22:00:43.052Z",
+            "confidence": 0.85
           }
         },
         "performances": {
@@ -61,6 +61,20 @@
             "source": "https://bsky.app/profile/calfurry.ca/post/3mfmjudnsx22i",
             "asOf": "2026-02-24T15:58:15.915Z",
             "confidence": 0.9
+          }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-07-05",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mpwl6nf6mm2x",
+            "asOf": "2026-07-05T22:00:29.130Z",
+            "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-08-02",
+            "source": "https://bsky.app/profile/calfurry.ca/post/3mpwl6nf6mm2x",
+            "asOf": "2026-07-05T22:00:29.130Z",
+            "confidence": 0.85
           }
         },
         "volunteers": {

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -32,10 +32,10 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-04-06",
-            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mitn7s24oc22",
-            "asOf": "2026-04-06T16:02:34.722Z",
-            "confidence": 0.9
+            "date": "2026-07-07",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mpzehwz2wc2c",
+            "asOf": "2026-07-07T00:38:24.515Z",
+            "confidence": 0.85
           }
         }
       }

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -50,6 +50,12 @@
           }
         },
         "djs": {
+          "opens": {
+            "date": "2026-05-14",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mltwp7h6wc2k",
+            "asOf": "2026-05-14T23:07:50.659Z",
+            "confidence": 0.85
+          },
           "closes": {
             "date": "2026-07-12",
             "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mpybpej7ts2u",

--- a/east.json
+++ b/east.json
@@ -22,9 +22,9 @@
         "registration": {
           "opens": {
             "date": "2026-03-15",
-            "source": "https://bsky.app/profile/sachsenfurs.de/post/3mgdjuvxrtc2r",
-            "asOf": "2026-03-05T19:29:49.437Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/sachsenfurs.de/post/3mh4jlb6x4c2k",
+            "asOf": "2026-03-15T18:00:59.132Z",
+            "confidence": 0.95
           }
         }
       }

--- a/eufuria.json
+++ b/eufuria.json
@@ -30,8 +30,8 @@
         "hotel": {
           "closes": {
             "date": "2026-07-08",
-            "source": "https://bsky.app/profile/eufuria.org/post/3mpnye2d6v423",
-            "asOf": "2026-07-02T12:02:11.723Z",
+            "source": "https://bsky.app/profile/eufuria.org/post/3mpz73acq742e",
+            "asOf": "2026-07-06T23:01:49.335Z",
             "confidence": 0.9
           }
         },
@@ -45,10 +45,10 @@
         },
         "performances": {
           "closes": {
-            "date": "2026-07-08",
-            "source": "https://bsky.app/profile/eufuria.org/post/3mnrswazsqg2y",
-            "asOf": "2026-06-08T13:45:15.998Z",
-            "confidence": 1
+            "date": "2026-07-15",
+            "source": "https://bsky.app/profile/eufuria.org/post/3mq3l2nrg3s2v",
+            "asOf": "2026-07-07T21:41:34.292Z",
+            "confidence": 0.85
           }
         },
         "volunteers": {

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -67,6 +67,12 @@
             "source": "https://bsky.app/profile/eurofurence.org/post/3mitn37gitk2g",
             "asOf": "2026-04-06T16:00:00.866Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-06-14",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mm55d3a3rs2o",
+            "asOf": "2026-05-18T15:00:17.418Z",
+            "confidence": 0.85
           }
         },
         "djs": {

--- a/fluufff.json
+++ b/fluufff.json
@@ -25,8 +25,8 @@
         "registration": {
           "opens": {
             "date": "2026-04-19",
-            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mietshbexx23",
-            "asOf": "2026-03-31T18:50:27.315Z",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3mjudr2vz452m",
+            "asOf": "2026-04-19T16:11:08.386Z",
             "confidence": 0.9
           }
         },

--- a/fureast.json
+++ b/fureast.json
@@ -25,8 +25,8 @@
         "registration": {
           "opens": {
             "date": "2026-02-06",
-            "source": "https://bsky.app/profile/fureast.fr/post/3mc34so4k3e25",
-            "asOf": "2026-01-10T13:33:50.998Z",
+            "source": "https://bsky.app/profile/fureast.fr/post/3me7o2clahj2e",
+            "asOf": "2026-02-06T19:43:23.170Z",
             "confidence": 0.9
           }
         },

--- a/furrydelphia.json
+++ b/furrydelphia.json
@@ -28,9 +28,9 @@
           },
           "closes": {
             "date": "2026-07-19",
-            "source": "https://bsky.app/profile/furrydelphia.org/post/3mpjso4l7up2j",
-            "asOf": "2026-06-30T20:09:47.275Z",
-            "confidence": 0.9
+            "source": "https://bsky.app/profile/furrydelphia.org/post/3mq2y6xilzs2z",
+            "asOf": "2026-07-07T16:03:46.220Z",
+            "confidence": 0.85
           }
         },
         "hotel": {

--- a/furvester.json
+++ b/furvester.json
@@ -25,9 +25,9 @@
         "dealers": {
           "opens": {
             "date": "2026-07-04",
-            "source": "https://bsky.app/profile/furvester.org/post/3movlydbobu2u",
-            "asOf": "2026-06-22T19:16:59.605Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/furvester.org/post/3mptncxdivl2r",
+            "asOf": "2026-07-04T18:00:42.097Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-07-18",

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -50,6 +50,12 @@
           }
         },
         "panels": {
+          "opens": {
+            "date": "2026-01-02",
+            "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mbhi2llkh22p",
+            "asOf": "2026-01-02T18:01:53.221Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-07-18",
             "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mko24hbmpa2s",

--- a/goldenhorn.json
+++ b/goldenhorn.json
@@ -39,9 +39,9 @@
           },
           "closes": {
             "date": "2026-06-05",
-            "source": "https://bsky.app/profile/goldenhorn.si/post/3mmtrjqnxslql",
-            "asOf": "2026-05-27T15:00:30.301Z",
-            "confidence": 0.92
+            "source": "https://bsky.app/profile/goldenhorn.si/post/3mncretbfgbck",
+            "asOf": "2026-06-02T14:07:41.338Z",
+            "confidence": 0.9
           }
         },
         "djs": {

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -24,9 +24,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-07-03",
-            "source": "https://bsky.app/profile/iwag.furries.id/post/3mpq7rgevqc27",
-            "asOf": "2026-07-03T09:20:16.269Z",
+            "date": "2026-01-03",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mbjfiwpeuc2k",
+            "asOf": "2026-01-03T12:21:32.891Z",
             "confidence": 0.9
           }
         },

--- a/indonesia-weekend-anthro-gathering.json
+++ b/indonesia-weekend-anthro-gathering.json
@@ -61,8 +61,8 @@
           },
           "closes": {
             "date": "2026-04-12",
-            "source": "https://bsky.app/profile/iwag.furries.id/post/3mi7c6zeaps22",
-            "asOf": "2026-03-29T13:52:02.914Z",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mj7tlzqorc2m",
+            "asOf": "2026-04-11T12:28:44.770Z",
             "confidence": 0.9
           }
         },
@@ -89,8 +89,8 @@
           },
           "closes": {
             "date": "2026-04-12",
-            "source": "https://bsky.app/profile/iwag.furries.id/post/3mi7c6zeaps22",
-            "asOf": "2026-03-29T13:52:02.914Z",
+            "source": "https://bsky.app/profile/iwag.furries.id/post/3mj7tlzqorc2m",
+            "asOf": "2026-04-11T12:28:44.770Z",
             "confidence": 0.9
           }
         }

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -37,10 +37,10 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-03-16",
-            "source": "https://bsky.app/profile/indyfurcon.org/post/3mh6mqha6wf26",
-            "asOf": "2026-03-16T14:02:53.622359Z",
-            "confidence": 0.92
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mplvipgci72m",
+            "asOf": "2026-07-01T16:05:47.057145683Z",
+            "confidence": 0.85
           },
           "closes": {
             "date": "2026-07-10",

--- a/infurnity.json
+++ b/infurnity.json
@@ -75,6 +75,12 @@
           }
         },
         "volunteers": {
+          "opens": {
+            "date": "2026-01-17",
+            "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mcms3y6ip22c",
+            "asOf": "2026-01-17T14:10:07.716Z",
+            "confidence": 0.8
+          },
           "closes": {
             "date": "2026-07-31",
             "source": "https://bsky.app/profile/infurnity.bsky.social/post/3mcms3y6ip22c",

--- a/megaplex.json
+++ b/megaplex.json
@@ -22,9 +22,9 @@
         "hotel": {
           "opens": {
             "date": "2026-03-11",
-            "source": "https://bsky.app/profile/megaplexcon.org/post/3mgnshullop2u",
-            "asOf": "2026-03-09T21:30:12.834Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mgsbc4deiz2n",
+            "asOf": "2026-03-11T16:06:04.706Z",
+            "confidence": 0.9
           }
         },
         "dealers": {

--- a/pawai.json
+++ b/pawai.json
@@ -28,9 +28,9 @@
           },
           "closes": {
             "date": "2026-06-30",
-            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mokzs6rpn22a",
-            "asOf": "2026-06-18T14:24:49.084Z",
-            "confidence": 0.95
+            "source": "https://bsky.app/profile/pawaiid.bsky.social/post/3mpjh4n7fy22s",
+            "asOf": "2026-06-30T16:43:10.550Z",
+            "confidence": 0.9
           }
         },
         "hotel": {

--- a/scotiacon.json
+++ b/scotiacon.json
@@ -33,8 +33,8 @@
         "dealers": {
           "opens": {
             "date": "2026-07-06",
-            "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3moxwtpk2xu2b",
-            "asOf": "2026-06-23T17:36:35.556Z",
+            "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3mpyoaf7w6k2m",
+            "asOf": "2026-07-06T18:00:28.666Z",
             "confidence": 0.9
           }
         }

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -40,9 +40,9 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-02-08",
-            "source": "https://bsky.app/profile/stratosfur.org/post/3meejidnyko2l",
-            "asOf": "2026-02-08T18:05:03.874130Z",
+            "date": "2026-03-11",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mgnxkoshxo2l",
+            "asOf": "2026-03-09T23:01:15.946391Z",
             "confidence": 0.8
           },
           "closes": {
@@ -82,10 +82,10 @@
             "confidence": 0.9
           },
           "closes": {
-            "date": "2026-04-30",
-            "source": "https://bsky.app/profile/stratosfur.org/post/3mijqcz5v6d2k",
-            "asOf": "2026-04-02T17:31:26.497297Z",
-            "confidence": 0.9
+            "date": "2026-05-16",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mleb2y3xbu26",
+            "asOf": "2026-05-08T17:30:46.995654Z",
+            "confidence": 0.85
           }
         },
         "volunteers": {

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -33,8 +33,8 @@
         "hotel": {
           "opens": {
             "date": "2026-06-19",
-            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mo4xxb7aq22f",
-            "asOf": "2026-06-13T00:14:35.571Z",
+            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mogjbetcx22i",
+            "asOf": "2026-06-16T19:18:26.179Z",
             "confidence": 0.9
           }
         }


### PR DESCRIPTION
Manual agent-driven sweep (no paid API — Claude-in-session extracted the dates from each con's own Bluesky feed) — running by hand until the automated importer is approved.

**This run:** 79 con accounts swept, 294 candidate dates extracted, 237 met the >= 0.80 confidence gate, **27 con files changed** after the merge (the rest were already current from the 2026-07-06 sweep). Covers all 7 schema categories including `performances` and `djs`.

- **alamo-city-furry-invasion** — dealers.closes, dealers.opens, djs.closes, djs.opens, hotel.opens
- **anthro-irish** — performances.closes, performances.opens, registration.opens
- **anthro-new-england** — dealers.closes, dealers.opens, registration.opens
- **anthro-socal** — dealers.closes, dealers.opens, djs.closes, djs.opens, hotel.opens, panels.closes, panels.opens, performances.closes, performances.opens, registration.opens
- **awoostria** — dealers.closes, djs.opens, panels.opens, registration.opens
- **big-sky-camp-paw** — djs.closes, djs.opens, panels.closes, registration.closes, registration.opens
- **biggest-little-fur-con** — dealers.closes, djs.closes, hotel.opens, panels.closes, registration.opens
- **calfurry** — djs.closes, djs.opens, panels.closes, panels.opens, volunteers.opens
- **capital-fur-con** — dealers.opens
- **carolina-furfare** — dealers.closes, djs.closes, djs.opens
- **east** — registration.opens
- **eufuria** — hotel.closes, performances.closes
- **eurofurence** — dealers.closes, djs.closes, djs.opens, performances.closes, registration.opens
- **fluufff** — dealers.opens, registration.opens
- **fureast** — dealers.closes, registration.opens
- **furrydelphia** — dealers.closes, dealers.opens, hotel.opens, panels.opens, registration.closes, registration.opens
- **furvester** — dealers.closes, dealers.opens
- **gateway-furmeet** — dealers.closes, dealers.opens, djs.opens, hotel.opens, panels.closes, panels.opens, registration.opens
- **goldenhorn** — dealers.closes, dealers.opens, registration.opens
- **indonesia-weekend-anthro-gathering** — dealers.opens, djs.closes, djs.opens, hotel.closes, hotel.opens, panels.closes, panels.opens, registration.opens, volunteers.closes
- **indyfurcon** — dealers.closes, dealers.opens, djs.closes, hotel.opens, panels.closes, registration.opens
- **infurnity** — dealers.closes, djs.closes, hotel.closes, hotel.opens, panels.closes, performances.closes, volunteers.closes, volunteers.opens
- **megaplex** — dealers.closes, dealers.opens, djs.closes, djs.opens, hotel.opens, panels.closes, panels.opens, performances.closes
- **pawai** — dealers.closes, dealers.opens, hotel.opens, performances.closes, performances.opens, registration.closes, registration.opens
- **scotiacon** — dealers.opens, registration.opens
- **stratosfur** — dealers.closes, dealers.opens, djs.closes, djs.opens, hotel.opens, panels.closes, panels.opens, registration.opens
- **western-pa-furry-weekend** — hotel.opens, registration.opens

---
Every entry cites its source Bluesky post; only confidence >= 0.80 is written, human-curated values are never overwritten, and an existing entry is only refreshed when a newer post restates it. A few entries reflect genuine updates the cons posted (e.g. deadline extensions at eufuria/stratosfur, later dealer waves at indyfurcon/capital-fur-con). Please review before merging.
