### PR TITLE
Key dates from Bluesky

### DIFF
--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -63,10 +63,10 @@
             "confidence": 0.95
           },
           "closes": {
-            "date": "2026-04-17",
-            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t",
-            "asOf": "2026-03-17T02:05:44.665Z",
-            "confidence": 0.95
+            "date": "2026-07-11",
+            "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mqcrgttmas24",
+            "asOf": "2026-07-10T18:24:23.927Z",
+            "confidence": 0.9
           }
         },
         "performances": {

--- a/aurawra.json
+++ b/aurawra.json
@@ -56,31 +56,31 @@
           }
         },
         "panels": {
-          "closes": {
-            "date": "2026-07-10",
-            "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
-            "asOf": "2026-06-04T05:49:59.850Z",
-            "confidence": 0.95
-          },
           "opens": {
             "date": "2026-02-24",
             "source": "https://bsky.app/profile/aurawra.org/post/3mflbqzs5sv2u",
             "asOf": "2026-02-24T04:00:34.786Z",
             "confidence": 0.9
-          }
-        },
-        "performances": {
+          },
           "closes": {
             "date": "2026-07-10",
             "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
             "asOf": "2026-06-04T05:49:59.850Z",
-            "confidence": 0.8
-          },
+            "confidence": 0.95
+          }
+        },
+        "performances": {
           "opens": {
             "date": "2026-06-04",
             "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
             "asOf": "2026-06-04T05:49:59.850Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
+            "asOf": "2026-06-04T05:49:59.850Z",
+            "confidence": 0.8
           }
         },
         "volunteers": {

--- a/aurawra.json
+++ b/aurawra.json
@@ -61,6 +61,12 @@
             "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
             "asOf": "2026-06-04T05:49:59.850Z",
             "confidence": 0.95
+          },
+          "opens": {
+            "date": "2026-02-24",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mflbqzs5sv2u",
+            "asOf": "2026-02-24T04:00:34.786Z",
+            "confidence": 0.9
           }
         },
         "performances": {
@@ -69,6 +75,12 @@
             "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
             "asOf": "2026-06-04T05:49:59.850Z",
             "confidence": 0.8
+          },
+          "opens": {
+            "date": "2026-06-04",
+            "source": "https://bsky.app/profile/aurawra.org/post/3mngwiqqedt2a",
+            "asOf": "2026-06-04T05:49:59.850Z",
+            "confidence": 0.9
           }
         },
         "volunteers": {

--- a/awoostria.json
+++ b/awoostria.json
@@ -72,6 +72,14 @@
             "asOf": "2026-04-16T15:35:10.427Z",
             "confidence": 0.9
           }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2025-11-15",
+            "source": "https://bsky.app/profile/awoostria.at/post/3m5mgr5ikrs2u",
+            "asOf": "2025-11-14T19:41:14.891Z",
+            "confidence": 0.8
+          }
         }
       }
     },

--- a/awoostria.json
+++ b/awoostria.json
@@ -33,6 +33,14 @@
             "confidence": 0.9
           }
         },
+        "hotel": {
+          "opens": {
+            "date": "2025-11-15",
+            "source": "https://bsky.app/profile/awoostria.at/post/3m5mgr5ikrs2u",
+            "asOf": "2025-11-14T19:41:14.891Z",
+            "confidence": 0.8
+          }
+        },
         "dealers": {
           "closes": {
             "date": "2025-11-29",
@@ -71,14 +79,6 @@
             "source": "https://bsky.app/profile/awoostria.at/post/3mjmqdyjmvs2z",
             "asOf": "2026-04-16T15:35:10.427Z",
             "confidence": 0.9
-          }
-        },
-        "hotel": {
-          "opens": {
-            "date": "2025-11-15",
-            "source": "https://bsky.app/profile/awoostria.at/post/3m5mgr5ikrs2u",
-            "asOf": "2025-11-14T19:41:14.891Z",
-            "confidence": 0.8
           }
         }
       }

--- a/barkada-furfest.json
+++ b/barkada-furfest.json
@@ -42,6 +42,12 @@
             "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mibstosk3k2p",
             "asOf": "2026-03-30T13:55:15.832Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-01",
+            "source": "https://bsky.app/profile/barkadafurfest.bsky.social/post/3mp75k65oss2h",
+            "asOf": "2026-06-26T14:25:09.724Z",
+            "confidence": 0.9
           }
         },
         "panels": {

--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -37,10 +37,10 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-04-16",
-            "source": "https://bsky.app/profile/goblfc.org/post/3mjnfxkjmta2c",
-            "asOf": "2026-04-16T22:01:53.648Z",
-            "confidence": 0.85
+            "date": "2026-05-26",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mmrvar2r6p2y",
+            "asOf": "2026-05-26T21:01:43.548Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-05-29",
@@ -67,10 +67,10 @@
         },
         "volunteers": {
           "opens": {
-            "date": "2026-04-17",
-            "source": "https://bsky.app/profile/goblfc.org/post/3mjpfqwvwnp2o",
-            "asOf": "2026-04-17T17:03:32.128Z",
-            "confidence": 1
+            "date": "2026-07-07",
+            "source": "https://bsky.app/profile/goblfc.org/post/3mq36w57c242m",
+            "asOf": "2026-07-07T18:04:17.289Z",
+            "confidence": 0.9
           }
         }
       }

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -36,6 +36,12 @@
             "source": "https://bsky.app/profile/capitalfurcon.org/post/3mpzehwz2wc2c",
             "asOf": "2026-07-07T00:38:24.515Z",
             "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-08-31",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mpzehwz2wc2c",
+            "asOf": "2026-07-07T00:38:24.515Z",
+            "confidence": 0.9
           }
         }
       }

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -29,10 +29,10 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-05-12",
-            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mlolrkmfms22",
-            "asOf": "2026-05-12T20:08:59.621Z",
-            "confidence": 0.85
+            "date": "2026-05-17",
+            "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mm2uze4d5c2n",
+            "asOf": "2026-05-17T17:26:21.776Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-05-25",

--- a/core-element.json
+++ b/core-element.json
@@ -32,6 +32,14 @@
             "asOf": "2026-06-22T18:20:22.815Z",
             "confidence": 0.85
           }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-04-03",
+            "source": "https://bsky.app/profile/coreelement.bsky.social/post/3miltyd7ifc2m",
+            "asOf": "2026-04-03T13:42:22.577Z",
+            "confidence": 0.8
+          }
         }
       }
     },

--- a/denfur.json
+++ b/denfur.json
@@ -42,6 +42,14 @@
             "asOf": "2026-01-27T11:02:26-08:00",
             "confidence": 0.85
           }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/denfur.org/post/3mq7xlci6ss2b",
+            "asOf": "2026-07-09T15:36:16.732Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/fluufff.json
+++ b/fluufff.json
@@ -82,7 +82,41 @@
       "latLng": [
         50.8442326,
         4.3474068
-      ]
+      ],
+      "keyDates": {
+        "panels": {
+          "opens": {
+            "date": "2025-06-24",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lsdx2gcrzk2d",
+            "asOf": "2025-06-24T11:01:40.424Z",
+            "confidence": 0.9
+          }
+        },
+        "registration": {
+          "opens": {
+            "date": "2025-06-01",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lqk7ppta5l2m",
+            "asOf": "2025-06-01T12:02:20.137Z",
+            "confidence": 1
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2025-06-01",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lqdmcewfzl2l",
+            "asOf": "2025-05-29T20:58:52.991Z",
+            "confidence": 0.9
+          }
+        },
+        "hotel": {
+          "closes": {
+            "date": "2025-07-31",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3ltwz4jozna2g",
+            "asOf": "2025-07-14T18:24:23.984Z",
+            "confidence": 0.9
+          }
+        }
+      }
     }
   ]
 }

--- a/fluufff.json
+++ b/fluufff.json
@@ -84,20 +84,20 @@
         4.3474068
       ],
       "keyDates": {
-        "panels": {
-          "opens": {
-            "date": "2025-06-24",
-            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lsdx2gcrzk2d",
-            "asOf": "2025-06-24T11:01:40.424Z",
-            "confidence": 0.9
-          }
-        },
         "registration": {
           "opens": {
             "date": "2025-06-01",
             "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lqk7ppta5l2m",
             "asOf": "2025-06-01T12:02:20.137Z",
             "confidence": 1
+          }
+        },
+        "hotel": {
+          "closes": {
+            "date": "2025-07-31",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3ltwz4jozna2g",
+            "asOf": "2025-07-14T18:24:23.984Z",
+            "confidence": 0.9
           }
         },
         "dealers": {
@@ -108,11 +108,11 @@
             "confidence": 0.9
           }
         },
-        "hotel": {
-          "closes": {
-            "date": "2025-07-31",
-            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3ltwz4jozna2g",
-            "asOf": "2025-07-14T18:24:23.984Z",
+        "panels": {
+          "opens": {
+            "date": "2025-06-24",
+            "source": "https://bsky.app/profile/fluufffcon.bsky.social/post/3lsdx2gcrzk2d",
+            "asOf": "2025-06-24T11:01:40.424Z",
             "confidence": 0.9
           }
         }

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -19,6 +19,14 @@
         -113.4929521
       ],
       "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-07-13",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqhkdtc7qv2e",
+            "asOf": "2026-07-12T16:00:45.132Z",
+            "confidence": 0.9
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-05-22",
@@ -55,14 +63,6 @@
             "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mpo726tt5f2c",
             "asOf": "2026-07-02T14:01:56.406380344Z",
             "confidence": 0.8
-          }
-        },
-        "registration": {
-          "closes": {
-            "date": "2026-07-13",
-            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqhkdtc7qv2e",
-            "asOf": "2026-07-12T16:00:45.132Z",
-            "confidence": 0.9
           }
         }
       }

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -56,6 +56,14 @@
             "asOf": "2026-07-02T14:01:56.406380344Z",
             "confidence": 0.8
           }
+        },
+        "registration": {
+          "closes": {
+            "date": "2026-07-13",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqhkdtc7qv2e",
+            "asOf": "2026-07-12T16:00:45.132Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/furlingame.json
+++ b/furlingame.json
@@ -19,20 +19,20 @@
         -122.3651261
       ],
       "keyDates": {
-        "hotel": {
-          "opens": {
-            "date": "2026-07-10",
-            "source": "https://bsky.app/profile/furlingame.com/post/3mqcjpxdqtc2w",
-            "asOf": "2026-07-10T16:06:19.656Z",
-            "confidence": 0.9
-          }
-        },
         "registration": {
           "opens": {
             "date": "2026-07-10",
             "source": "https://bsky.app/profile/furlingame.com/post/3mqcjmlgxl22w",
             "asOf": "2026-07-10T16:04:26.512Z",
             "confidence": 0.95
+          }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/furlingame.com/post/3mqcjpxdqtc2w",
+            "asOf": "2026-07-10T16:06:19.656Z",
+            "confidence": 0.9
           }
         }
       }

--- a/furlingame.json
+++ b/furlingame.json
@@ -17,7 +17,25 @@
       "latLng": [
         37.5938725,
         -122.3651261
-      ]
+      ],
+      "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/furlingame.com/post/3mqcjpxdqtc2w",
+            "asOf": "2026-07-10T16:06:19.656Z",
+            "confidence": 0.9
+          }
+        },
+        "registration": {
+          "opens": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/furlingame.com/post/3mqcjmlgxl22w",
+            "asOf": "2026-07-10T16:04:26.512Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "furlingame-2026",

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -27,9 +27,9 @@
             "confidence": 0.95
           },
           "closes": {
-            "date": "2026-06-28",
-            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mp7ryc6p7y2r",
-            "asOf": "2026-06-26T20:30:58.541Z",
+            "date": "2026-07-27",
+            "source": "https://bsky.app/profile/furcon.bsky.social/post/3mqfmc4qeiu2s",
+            "asOf": "2026-07-11T21:30:15.967Z",
             "confidence": 0.95
           }
         },

--- a/indyfurcon.json
+++ b/indyfurcon.json
@@ -63,6 +63,12 @@
             "source": "https://bsky.app/profile/indyfurcon.org/post/3mlvm4osnqc2x",
             "asOf": "2026-05-15T15:03:51.046596Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-08-01",
+            "source": "https://bsky.app/profile/indyfurcon.org/post/3mq5krcpqyf2i",
+            "asOf": "2026-07-08T16:41:39.953084239Z",
+            "confidence": 1
           }
         },
         "djs": {

--- a/megaplex.json
+++ b/megaplex.json
@@ -57,10 +57,10 @@
         },
         "performances": {
           "opens": {
-            "date": "2026-04-11",
-            "source": "https://bsky.app/profile/megaplexcon.org/post/3mja7l72apw2w",
-            "asOf": "2026-04-11T16:03:01.657Z",
-            "confidence": 0.85
+            "date": "2026-07-12",
+            "source": "https://bsky.app/profile/megaplexcon.org/post/3mqi35voeug2z",
+            "asOf": "2026-07-12T21:01:39.954Z",
+            "confidence": 0.9
           },
           "closes": {
             "date": "2026-06-15",

--- a/noctfurnal.json
+++ b/noctfurnal.json
@@ -23,17 +23,17 @@
       ],
       "keyDates": {
         "registration": {
-          "closes": {
-            "date": "2026-05-01",
-            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mkijpprxxk2a",
-            "asOf": "2026-04-27T16:51:00.397Z",
-            "confidence": 0.95
-          },
           "opens": {
             "date": "2026-07-11",
             "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mqdm35nm222e",
             "asOf": "2026-07-11T02:21:02.564Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-05-01",
+            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mkijpprxxk2a",
+            "asOf": "2026-04-27T16:51:00.397Z",
+            "confidence": 0.95
           }
         },
         "dealers": {

--- a/noctfurnal.json
+++ b/noctfurnal.json
@@ -28,6 +28,12 @@
             "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mkijpprxxk2a",
             "asOf": "2026-04-27T16:51:00.397Z",
             "confidence": 0.95
+          },
+          "opens": {
+            "date": "2026-07-11",
+            "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mqdm35nm222e",
+            "asOf": "2026-07-11T02:21:02.564Z",
+            "confidence": 0.9
           }
         },
         "dealers": {

--- a/pawstral.json
+++ b/pawstral.json
@@ -37,6 +37,14 @@
             "asOf": "2026-05-18T02:24:37.203Z",
             "confidence": 0.82
           }
+        },
+        "hotel": {
+          "opens": {
+            "date": "2026-05-03",
+            "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mkxvmsthxs2k",
+            "asOf": "2026-05-03T19:34:03.888Z",
+            "confidence": 0.8
+          }
         }
       }
     },

--- a/pawstral.json
+++ b/pawstral.json
@@ -30,20 +30,20 @@
             "confidence": 0.85
           }
         },
-        "panels": {
-          "opens": {
-            "date": "2026-05-18",
-            "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mm3t3tgpwk2x",
-            "asOf": "2026-05-18T02:24:37.203Z",
-            "confidence": 0.82
-          }
-        },
         "hotel": {
           "opens": {
             "date": "2026-05-03",
             "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mkxvmsthxs2k",
             "asOf": "2026-05-03T19:34:03.888Z",
             "confidence": 0.8
+          }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-05-18",
+            "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mm3t3tgpwk2x",
+            "asOf": "2026-05-18T02:24:37.203Z",
+            "confidence": 0.82
           }
         }
       }

--- a/scotiacon.json
+++ b/scotiacon.json
@@ -36,6 +36,12 @@
             "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3mpyoaf7w6k2m",
             "asOf": "2026-07-06T18:00:28.666Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-12",
+            "source": "https://bsky.app/profile/scotiacon.bsky.social/post/3mqhlyu7rak2z",
+            "asOf": "2026-07-12T16:30:24.544Z",
+            "confidence": 0.95
           }
         }
       }

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -24,9 +24,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-02-10",
-            "source": "https://bsky.app/profile/stratosfur.org/post/3meht4mvwec2k",
-            "asOf": "2026-02-10T01:35:27.540709Z",
+            "date": "2026-02-11",
+            "source": "https://bsky.app/profile/stratosfur.org/post/3mekeykdc5s2l",
+            "asOf": "2026-02-11T02:00:37.458947Z",
             "confidence": 0.95
           }
         },

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -67,6 +67,14 @@
             "asOf": "2026-06-03T22:00:12.304Z",
             "confidence": 0.9
           }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-30",
+            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mpk2g3cqwl2i",
+            "asOf": "2026-06-30T22:28:28.256Z",
+            "confidence": 0.8
+          }
         }
       }
     }

--- a/west-aussie-fur-frenzy.json
+++ b/west-aussie-fur-frenzy.json
@@ -17,7 +17,25 @@
       "latLng": [
         -32.0573082,
         115.7463379
-      ]
+      ],
+      "keyDates": {
+        "dealers": {
+          "closes": {
+            "date": "2026-04-12",
+            "source": "https://bsky.app/profile/waff.net.au/post/3mixkebaobk2b",
+            "asOf": "2026-04-08T05:22:02.613Z",
+            "confidence": 0.9
+          }
+        },
+        "registration": {
+          "opens": {
+            "date": "2026-05-28",
+            "source": "https://bsky.app/profile/waff.net.au/post/3mmvnuq2ims2b",
+            "asOf": "2026-05-28T09:00:23.269Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "west-aussie-fur-frenzy-2025",

--- a/west-aussie-fur-frenzy.json
+++ b/west-aussie-fur-frenzy.json
@@ -19,20 +19,20 @@
         115.7463379
       ],
       "keyDates": {
-        "dealers": {
-          "closes": {
-            "date": "2026-04-12",
-            "source": "https://bsky.app/profile/waff.net.au/post/3mixkebaobk2b",
-            "asOf": "2026-04-08T05:22:02.613Z",
-            "confidence": 0.9
-          }
-        },
         "registration": {
           "opens": {
             "date": "2026-05-28",
             "source": "https://bsky.app/profile/waff.net.au/post/3mmvnuq2ims2b",
             "asOf": "2026-05-28T09:00:23.269Z",
             "confidence": 0.95
+          }
+        },
+        "dealers": {
+          "closes": {
+            "date": "2026-04-12",
+            "source": "https://bsky.app/profile/waff.net.au/post/3mixkebaobk2b",
+            "asOf": "2026-04-08T05:22:02.613Z",
+            "confidence": 0.9
           }
         }
       }

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -37,6 +37,14 @@
             "asOf": "2026-06-16T19:18:26.179Z",
             "confidence": 0.9
           }
+        },
+        "panels": {
+          "opens": {
+            "date": "2026-07-09",
+            "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mq7rc2zwms26",
+            "asOf": "2026-07-09T13:43:44.467Z",
+            "confidence": 0.95
+          }
         }
       }
     },

--- a/wild-north.json
+++ b/wild-north.json
@@ -21,10 +21,10 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-03-13",
-            "source": "https://bsky.app/profile/wildnorth.bsky.social/post/3mgxm3gih7k2y",
-            "asOf": "2026-03-13T19:02:30.320Z",
-            "confidence": 0.88
+            "date": "2026-04-25",
+            "source": "https://bsky.app/profile/wildnorth.bsky.social/post/3mkdn5vtqhs2a",
+            "asOf": "2026-04-25T18:09:19.044Z",
+            "confidence": 0.8
           },
           "closes": {
             "date": "2026-06-09",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-12_

### Applied (unanimously verified)

**brasil-furfest.json** — `brasil-furfest-2026` hotel.opens → **2025-09-17** (add, conf 0.8)
> HOTEL OVERFLOW DISPONÍVEL BFF 2026: SLEEP INN PAULÍNIA - Quartos para 2: R$ 500 + taxas/noite - Café da manhã incluso - Transporte gratuito pro Premium Hotel nos dias de evento 📦 Primeiro lote: 40 quartos 💵 Pagamento PIX, Débito e Crédito (com parcelamento) 🌐 Reservas reg.brasilfurfest.com.br
> — [source post](https://bsky.app/profile/brasilfurfest.bsky.social/post/3lyyoadqocs22) at 2025-09-17T01:20:59.678Z

### Refuted by verification (not applied)
- `brasil-furfest-2026` registration.opens 2025-09-21 — The post celebrates the 'first night of ticket sales' for Brasil FurFest 2026 and encourages people to buy tickets, with a 'first lot' available until 21/10. Th