### PR TITLE
Key dates from Bluesky

### DIFF
--- a/fur-eh.json
+++ b/fur-eh.json
@@ -50,6 +50,12 @@
           }
         },
         "performances": {
+          "opens": {
+            "date": "2026-07-10",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqbb5nnmct2n",
+            "asOf": "2026-07-10T04:00:15.389618096Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-06-30",
             "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mpjs5wgjwj2d",
@@ -59,10 +65,10 @@
         },
         "volunteers": {
           "opens": {
-            "date": "2026-07-02",
-            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mpo726tt5f2c",
-            "asOf": "2026-07-02T14:01:56.406380344Z",
-            "confidence": 0.8
+            "date": "2026-07-08",
+            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mq5btbcot52j",
+            "asOf": "2026-07-08T14:01:41.510999225Z",
+            "confidence": 0.9
           }
         }
       }


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-13_

### Applied (unanimously verified)

**fur-eh.json** — `fur-eh-2026` performances.opens → **2026-07-10** (add, conf 0.9)
> There may be limited space for at-con signups, but why chance it? Sign up for Floor Wars at Fur-Eh! 2026 today at https://fureh.ca/floor! #FurEh #FEH2026 #Furry #FloorWars #DanceBattle
> — [source post](https://bsky.app/profile/fur-eh.bsky.social/post/3mqbb5nnmct2n) at 2026-07-10T04:00:15.389618096Z

**fur-eh.json** — `fur-eh-2026` volunteers.opens → **2026-07-08** (amend 2026-07-02 -> 2026-07-08, conf 0.9)
> Can you lend a paw? 🐾 We're going there and back again in a little over a week. If you'd like to pitch in and help make this an adventure to write about, apply today at https://fureh.ca/volunteer! There are a wide variety of opportunities available. #FurEh #FEH2026
> — [source post](https://bsky.app/profile/fur-eh.bsky.social/post/3mq5btbcot52j) at 2026-07-08T14:01:41.510999225Z