### PR TITLE
Keep git output out of the reject script's stdout

### DIFF
--- a/.github/scripts/keydates_reject.py
+++ b/.github/scripts/keydates_reject.py
@@ -59,19 +59,21 @@ def main() -> int:
         json.dump(rejections, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
-    subprocess.run(["git", "config", "user.name", "cons.fyi GitHub bot"], check=True)
-    subprocess.run(["git", "config", "user.email", "github@cons.fyi"], check=True)
-    subprocess.run(["git", "add", ".github/keydates_rejections.json"], check=True)
-    subprocess.run(
-        ["git", "commit", "-m", f"Reject key date {event_id} {category}.{kind} {date}"],
-        check=True,
-    )
+    # our stdout is captured into $GITHUB_OUTPUT — only the sentinel word may
+    # reach it, so route every git subprocess's stdout to stderr
+    def git(*args, check=True):
+        return subprocess.run(["git", *args], check=check, stdout=sys.stderr)
+
+    git("config", "user.name", "cons.fyi GitHub bot")
+    git("config", "user.email", "github@cons.fyi")
+    git("add", ".github/keydates_rejections.json")
+    git("commit", "-m", f"Reject key date {event_id} {category}.{kind} {date}")
     # two racing /reject comments: rebase and retry the push
     for _ in range(3):
-        if subprocess.run(["git", "push"], check=False).returncode == 0:
+        if git("push", check=False).returncode == 0:
             print("ok", end="")
             return 0
-        subprocess.run(["git", "pull", "--rebase"], check=True)
+        git("pull", "--rebase")
     print("push-failure", end="")
     return 1
 


### PR DESCRIPTION
Every successful `/reject` turned the `keydates_reject` run red: the **Record rejection** step captures the script's stdout with `result=$(python3 …)`, but `git commit` (and `git pull --rebase` on the retry path) also write to stdout, so the captured value went multiline and the `$GITHUB_OUTPUT` write failed with `Invalid format ' 1 file changed, 11 insertions(+), 1 deletion(-)'`. The rejection itself was still committed and pushed, but the step errored and the **React** step never ran — no 👍/👎 feedback on the comment. Seen live on [run 29291980667](https://github.com/consfyi/data/actions/runs/29291980667) handling the megaplex-2026 rejection on #51.

Fix: route every git subprocess's stdout to stderr via a small `git()` helper, so the only thing reaching the captured stdout is the sentinel word (`ok`/`duplicate`/`parse-failure`/`push-failure`). The git output still lands in the Actions log via stderr.

Verified in a sandbox repo with a local bare remote:
- old script through the same `$( )` capture reproduces the exact multiline pollution from the failed run
- new script, replaying the workflow step verbatim (`bash -e` + `echo "result=$result" >> "$GITHUB_OUTPUT"`): exit 0, output file contains exactly `result=ok`
- `duplicate` and `parse-failure` paths also emit only their sentinel
- the React step's reaction call was exercised manually against the missed comment on #51 (it now has its 👍)