### PR TITLE
Key dates from Bluesky

### DIFF
--- a/aquatifur.json
+++ b/aquatifur.json
@@ -42,6 +42,14 @@
             "asOf": "2026-07-01T17:06:37.996Z",
             "confidence": 0.9
           }
+        },
+        "volunteers": {
+          "opens": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/did:plc:efgqcoutfj3rxzkeihyaz26q/post/3mqmy6iw3ad2e",
+            "asOf": "2026-07-14T19:51:37.533Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -43,6 +43,20 @@
             "asOf": "2026-07-07T00:38:24.515Z",
             "confidence": 0.9
           }
+        },
+        "djs": {
+          "opens": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mqmnl4ke2s2l",
+            "asOf": "2026-07-14T16:41:49.694Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-12-01",
+            "source": "https://bsky.app/profile/capitalfurcon.org/post/3mqmnl4ke2s2l",
+            "asOf": "2026-07-14T16:41:49.694Z",
+            "confidence": 0.9
+          }
         }
       }
     }

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -21,9 +21,9 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-02-08",
-            "source": "https://bsky.app/profile/eurofurence.org/post/3mddqnjlbwc2j",
-            "asOf": "2026-01-26T17:15:22.873Z",
+            "date": "2026-03-01",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mfz4ekakcs24",
+            "asOf": "2026-03-01T16:01:24.128Z",
             "confidence": 0.9
           },
           "closes": {

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -44,6 +44,12 @@
             "source": "https://bsky.app/profile/futrolajki.pl/post/3mpm43gum4s2k",
             "asOf": "2026-07-01T18:03:38.407Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/did:plc:oy67eitzxchghmwagnebvp56/post/3mqmvsultic2l",
+            "asOf": "2026-07-14T19:09:19.718Z",
+            "confidence": 0.9
           }
         },
         "djs": {

--- a/nordicfuzzcon.json
+++ b/nordicfuzzcon.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "volunteers": {
+          "opens": {
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/did:plc:i7jct5sy4z2tb2q7gritvhjc/post/3mqmlajy6i52o",
+            "asOf": "2026-07-14T16:00:05.962Z",
+            "confidence": 0.9
+          }
+        }
+      }
     },
     {
       "id": "nordicfuzzcon-2026",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-14_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**aquatifur.json** — `aquatifur-2026` volunteers.opens → **2026-07-14** (add, conf 0.9)
> #AQF Sign up to volunteer at AquatiFur! https://aquatifur.org/apply/volunteer/
> — [source post](https://bsky.app/profile/did:plc:efgqcoutfj3rxzkeihyaz26q/post/3mqmy6iw3ad2e) at 2026-07-14T19:51:37.533Z

**nordicfuzzcon.json** — `nordicfuzzcon-2027` volunteers.opens → **2026-07-14** (add, conf 0.9)
> Interested in joining NordicFuzzCon STEW (Staff & Crew)? Our recruitment page has several open positions, including multiple roles in our Security, Stage, and Events teams. For any questions, please e-mail us at hr@nordicfuzzcon.org. nfuzz.co/recruitment 🎨 Neotheta
> — [source post](https://bsky.app/profile/did:plc:i7jct5sy4z2tb2q7gritvhjc/post/3mqmlajy6i52o) at 2026-07-14T16:00:05.962Z

**capital-fur-con.json** — `capital-fur-con-2027` djs.opens → **2026-07-14** (add, conf 0.9)
> GOOD AFTERNOON #FURRY UNIVERSE >> 🔥DJ APPS ARE OPEN 🔥 << THATS RIGHT ! ! ! IF YOU WANT 2 SPIN 🎶🎚️ ON MAINSTAGE, APPLY!🗒️ capitalfurcon.org/main-events 🚨 DEADLINE: DEC 1ST 🚨 IF ACCEPTED, YOU'LL HEAR AFTER DEC 1ST WE CANT WAIT TO SEE WHAT YOU'VE GOT!!!! #CFC2027 #CAPITALFURCON
> — [source post](https://bsky.app/profile/capitalfurcon.org/post/3mqmnl4ke2s2l) at 2026-07-14T16:41:49.694Z

**capital-fur-con.json** — `capital-fur-con-2027` djs.closes → **2026-12-01** (add, conf 0.9)
> GOOD AFTERNOON #FURRY UNIVERSE >> 🔥DJ APPS ARE OPEN 🔥 << THATS RIGHT ! ! ! IF YOU WANT 2 SPIN 🎶🎚️ ON MAINSTAGE, APPLY!🗒️ capitalfurcon.org/main-events 🚨 DEADLINE: DEC 1ST 🚨 IF ACCEPTED, YOU'LL HEAR AFTER DEC 1ST WE CANT WAIT TO SEE WHAT YOU'VE GOT!!!! #CFC2027 #CAPITALFURCON
> — [source post](https://bsky.app/profile/capitalfurcon.org/post/3mqmnl4ke2s2l) at 2026-07-14T16:41:49.694Z

**eurofurence.json** — `eurofurence-30` registration.opens → **2026-03-01** (amend 2026-02-08 -> 2026-03-01, conf 0.9)
> ✨ Lights up, paws out - Eurofurence awaits! Take your first step towards #EF30 today and register at eurofurence.org. Payments before the 18th of March receive a 15€ discount. #Eurofurence 30 🗓August 19-23, 2026 📍 CCH Hamburg
> — [source post](https://bsky.app/profile/eurofurence.org/post/3mfz4ekakcs24) at 2026-03-01T16:01:24.128Z

**futrolajki.json** — `futrolajki-2026` dealers.closes → **2026-07-14** (add, conf 0.9)
> 🇬🇧 These are the final hours! Reminder that Dealer's Den applications close tonight at midnight If you haven't submitted your application yet, now is the time! Once the application period ends, you won't be able to register your booth Form can be found here: events.foxcons.pl/fl26dd See you there
> — [source post](https://bsky.app/profile/did:plc:oy67eitzxchghmwagnebvp56/post/3mqmvsultic2l) at 2026-07-14T19:09:19.718Z

### Refuted by verification (not applied)
- `aquatifur-2026` djs.opens 2025-08-05 — source post (2025-07-03) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` panels.opens 2025-08-05 — source post (2025-07-03) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` djs.closes 2025-08-10 — source post (2025-08-10) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` panels.closes 2025-08-10 — source post (2025-08-10) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` performances.opens 2025-08-24 — source post (2025-08-24) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` performances.closes 2025-11-01 — source post (2025-08-24) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition
- `aquatifur-2026` registration.closes 2025-09-30 — source post (2025-09-30) predates the previous edition's end (2025-11-09) — almost certainly refers to an earlier edition