### PR TITLE
Validate /reject dates and remove the rejection stored from a truncated date

### DIFF
--- a/.github/keydates_rejections.json
+++ b/.github/keydates_rejections.json
@@ -19,15 +19,6 @@
   },
   {
     "event_id": "biggest-little-fur-con-2026",
-    "category": "performances",
-    "kind": "opens",
-    "date": "2026-07-12",
-    "reason": "5 - this date is already in place and the new post just mentions that its already open.",
-    "by": "sparkyfen",
-    "at": "2026-07-16T22:18:51Z"
-  },
-  {
-    "event_id": "biggest-little-fur-con-2026",
     "category": "panels",
     "kind": "opens",
     "date": "2026-05-20",

--- a/.github/scripts/keydates_reject.py
+++ b/.github/scripts/keydates_reject.py
@@ -9,30 +9,45 @@ reads that file each run and never re-proposes a matching date.
 Syntax:  /reject <event_id> <category>.<kind> <date> — <reason...>
 Example: /reject anthrocon-2026 registration.closes 2026-06-26 — that's the pre-reg deadline
 """
+import datetime
 import json
 import os
 import re
 import subprocess
 import sys
 
+# (?!\S) forces the date to end at whitespace/end-of-comment: without it,
+# a typo like 2026-07-125 matched as date 2026-07-12 with the stray "5"
+# swallowed into the reason.
 GRAMMAR = re.compile(
     r"^/reject\s+([a-z0-9-]+)\s+"
     r"(registration|hotel|dealers|panels|performances|djs|volunteers)\.(opens|closes)\s+"
-    r"(\d{4}-\d{2}-\d{2})\s*(?:[—–-]+\s*)?(.*)$",
+    r"(\d{4}-\d{2}-\d{2})(?!\S)\s*(?:[—–-]+\s*)?(.*)$",
     re.S,
 )
+
+def parse(body):
+    """Parse a /reject comment. Returns (fields, None) or (None, error)."""
+    m = GRAMMAR.match(body.strip())
+    if not m:
+        return None, "parse-failure"
+    try:
+        datetime.date.fromisoformat(m.group(4))
+    except ValueError:
+        return None, "invalid-date"
+    return m.groups(), None
 
 def main() -> int:
     body = os.environ.get("COMMENT_BODY", "")
     user = os.environ.get("COMMENT_USER", "")
     created = os.environ.get("COMMENT_CREATED_AT", "")
 
-    m = GRAMMAR.match(body.strip())
-    if not m:
-        print("parse-failure", end="")
+    fields, err = parse(body)
+    if err:
+        print(err, end="")
         return 0  # workflow reacts with 👎 based on the output
 
-    event_id, category, kind, date, reason = m.groups()
+    event_id, category, kind, date, reason = fields
     reason = " ".join(reason.split())[:300]  # collapse whitespace, cap length
 
     with open(".github/keydates_rejections.json") as f:

--- a/.github/scripts/test_keydates_reject.py
+++ b/.github/scripts/test_keydates_reject.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Unit tests for the /reject comment parser. Run directly:
+python3 .github/scripts/test_keydates_reject.py"""
+import unittest
+
+from keydates_reject import parse
+
+
+class TestParse(unittest.TestCase):
+    def test_valid_comment(self):
+        fields, err = parse(
+            "/reject anthrocon-2026 registration.closes 2026-06-26 — that's the pre-reg deadline"
+        )
+        self.assertIsNone(err)
+        self.assertEqual(
+            fields,
+            ("anthrocon-2026", "registration", "closes", "2026-06-26",
+             "that's the pre-reg deadline"),
+        )
+
+    def test_valid_without_reason(self):
+        fields, err = parse("/reject anthrocon-2026 hotel.opens 2026-01-05")
+        self.assertIsNone(err)
+        self.assertEqual(fields[3], "2026-01-05")
+
+    def test_overlong_day_is_rejected(self):
+        # regression: 2026-07-125 used to parse as 2026-07-12 with the
+        # stray "5" swallowed into the reason
+        fields, err = parse(
+            "/reject biggest-little-fur-con-2026 performances.opens 2026-07-125 "
+            "— this date is already in place"
+        )
+        self.assertIsNone(fields)
+        self.assertEqual(err, "parse-failure")
+
+    def test_impossible_month(self):
+        fields, err = parse("/reject anthrocon-2026 hotel.opens 2026-13-01 — nope")
+        self.assertIsNone(fields)
+        self.assertEqual(err, "invalid-date")
+
+    def test_impossible_day(self):
+        fields, err = parse("/reject anthrocon-2026 hotel.opens 2026-02-30 — nope")
+        self.assertIsNone(fields)
+        self.assertEqual(err, "invalid-date")
+
+    def test_unknown_category(self):
+        fields, err = parse("/reject anthrocon-2026 parking.opens 2026-06-26 — x")
+        self.assertEqual(err, "parse-failure")
+
+    def test_garbage(self):
+        fields, err = parse("/reject please")
+        self.assertEqual(err, "parse-failure")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/keydates_reject.yml
+++ b/.github/workflows/keydates_reject.yml
@@ -61,9 +61,14 @@ jobs:
             content="+1"
           else
             content="-1"
+            if [ "$RESULT" = "invalid-date" ]; then
+              msg="That date isn't a real calendar date. Syntax: \`/reject <event_id> <category>.<kind> <YYYY-MM-DD> — <reason>\`"
+            else
+              msg="Could not parse that. Syntax: \`/reject <event_id> <category>.<kind> <YYYY-MM-DD> — <reason>\`"
+            fi
             gh api --method POST \
               "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
-              -f body="Could not parse that. Syntax: \`/reject <event_id> <category>.<kind> <YYYY-MM-DD> — <reason>\`" || true
+              -f body="$msg" || true
           fi
           gh api --method POST \
             "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,3 +26,5 @@ jobs:
         run: |
           mkdir "$RUNNER_TEMP/out"
           uv run tools/materialize.py "$RUNNER_TEMP/out"
+      - name: Reject-parser unit tests
+        run: python3 .github/scripts/test_keydates_reject.py


### PR DESCRIPTION
## What

- `/reject` comments now require the date token to end at whitespace: `2026-07-125` previously matched the grammar as `2026-07-12` and the stray `5` was swallowed into the reason text. It now fails to parse (👎 + syntax reply).
- Parsed dates are checked with `date.fromisoformat`, so impossible dates like `2026-13-01` are refused with a specific reply instead of being stored.
- Parsing is factored into `parse()` with unit tests (including a regression test for the exact `2026-07-125` comment), run in the `validate` workflow on every PR.
- Removes the rejection entry that the truncation bug stored on main (`biggest-little-fur-con-2026 performances.opens 2026-07-12`, reason beginning "5 - ..."). The intended rejection for `2026-07-15` stays.

## Why

While that entry lingers, any future legitimate proposal of `performances.opens 2026-07-12` for BLFC 2026 would be silently skipped.

Tracked in Linear: CON-21