### PR TITLE
Revert three bad key-date merges from keydates bot PR #54

### DIFF
--- a/.github/keydates_rejections.json
+++ b/.github/keydates_rejections.json
@@ -34,5 +34,32 @@
     "reason": "this date is already in place and the new post just mentions that its already open.",
     "by": "sparkyfen",
     "at": "2026-07-16T22:20:17Z"
+  },
+  {
+    "event_id": "eurofurence-30",
+    "category": "performances",
+    "kind": "closes",
+    "date": "2026-06-01",
+    "reason": "bot PR #54 cross-attributed post 3mmwby32qdc22 (Furdance/Nightclub applications before June 1) to dance-competition registrations; the real close is 2026-06-14 from post 3mm55d3a3rs2o.",
+    "by": "sparkyfen",
+    "at": "2026-07-17T06:10:20Z"
+  },
+  {
+    "event_id": "futrolajki-2026",
+    "category": "dealers",
+    "kind": "closes",
+    "date": "2026-07-15",
+    "reason": "bot PR #54 read the Polish half of a bilingual 'Dealer's Den closes tonight at midnight' announcement (posted 2026-07-14) as a 07-15 close; last day open is 2026-07-14.",
+    "by": "sparkyfen",
+    "at": "2026-07-17T06:10:20Z"
+  },
+  {
+    "event_id": "fur-eh-2026",
+    "category": "registration",
+    "kind": "opens",
+    "date": "2026-07-16",
+    "reason": "bot PR #54 added a registration.opens on the con's own start day (at-door/day-of), three days after registration.closes 2026-07-13; removed as spurious.",
+    "by": "sparkyfen",
+    "at": "2026-07-17T06:10:20Z"
   }
 ]

--- a/eurofurence.json
+++ b/eurofurence.json
@@ -69,10 +69,10 @@
             "confidence": 0.9
           },
           "closes": {
-            "date": "2026-06-01",
-            "source": "https://bsky.app/profile/eurofurence.org/post/3mmwby32qdc22",
-            "asOf": "2026-05-28T15:00:10.303Z",
-            "confidence": 0.95
+            "date": "2026-06-14",
+            "source": "https://bsky.app/profile/eurofurence.org/post/3mm55d3a3rs2o",
+            "asOf": "2026-05-18T15:00:17.418Z",
+            "confidence": 0.85
           }
         },
         "djs": {

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -20,12 +20,6 @@
       ],
       "keyDates": {
         "registration": {
-          "opens": {
-            "date": "2026-07-16",
-            "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqrkixua7c24",
-            "asOf": "2026-07-16T15:30:15.082470786Z",
-            "confidence": 0.9
-          },
           "closes": {
             "date": "2026-07-13",
             "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqhkdtc7qv2e",

--- a/futrolajki.json
+++ b/futrolajki.json
@@ -46,10 +46,10 @@
             "confidence": 0.9
           },
           "closes": {
-            "date": "2026-07-15",
-            "source": "https://bsky.app/profile/futrolajki.pl/post/3mqmvtjntts2l",
-            "asOf": "2026-07-14T19:09:41.810Z",
-            "confidence": 0.95
+            "date": "2026-07-14",
+            "source": "https://bsky.app/profile/did:plc:oy67eitzxchghmwagnebvp56/post/3mqmvsultic2l",
+            "asOf": "2026-07-14T19:09:19.718Z",
+            "confidence": 0.9
           }
         },
         "djs": {


### PR DESCRIPTION
PR #54 introduced three incorrect key dates. This restores each to its pre-#54 value and records matching rejections so the ingest worker won't re-propose them.

- **Eurofurence 30 — performances.closes: back to 2026-06-14.** #54 attributed a Furdance/Nightclub application deadline (post 3mmwby32qdc22, "apply before June 1st") to the dance-competition registration field; the correct source (3mm55d3a3rs2o) says dance-competition registration "closes at the 14th of June."
- **Futrolajki 2026 — dealers.closes: back to 2026-07-14.** The two source posts are the same bilingual "Dealer's Den applications close tonight at midnight" announcement (EN + PL, posted 2026-07-14 twenty-two seconds apart), so this was a midnight-boundary re-read of identical information, not newer information. "Closes" here means the last day applications are open: 07-14.
- **Fur-Eh! 2026 — registration.opens: removed (was 2026-07-16).** The post is the con's on-site registration desk opening on its own start day, not the online signup; it also contradicted registration.closes = 2026-07-13.

Each misread was confirmed against the live source posts before reverting. Also adds the three values to `.github/keydates_rejections.json`.

Validation: format.py canonical, materialize.py schema checks pass, reject-script tests 7/7.