### PR TITLE
Key dates from Bluesky

### DIFF
--- a/alamo-city-furry-invasion.json
+++ b/alamo-city-furry-invasion.json
@@ -71,9 +71,9 @@
             "confidence": 0.8
           },
           "closes": {
-            "date": "2026-09-24",
-            "source": "https://bsky.app/profile/did:plc:i54z3b7sl4jladt3k56ttsoa/post/3mqpwclp3622j",
-            "asOf": "2026-07-15T23:56:06.478Z",
+            "date": "2026-09-20",
+            "source": "https://bsky.app/profile/furryinvasion.bsky.social/post/3mquh742hhc27",
+            "asOf": "2026-07-17T19:09:01.977Z",
             "confidence": 0.85
           }
         },

--- a/furrest-city.json
+++ b/furrest-city.json
@@ -30,6 +30,20 @@
             "confidence": 0.9
           }
         },
+        "dealers": {
+          "opens": {
+            "date": "2026-07-19",
+            "source": "https://bsky.app/profile/did:plc:gs3oxjmihf65m2efx2xu75rr/post/3mqwm6mfids2i",
+            "asOf": "2026-07-18T15:43:33.745Z",
+            "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-29",
+            "source": "https://bsky.app/profile/did:plc:gs3oxjmihf65m2efx2xu75rr/post/3mqwm6mfids2i",
+            "asOf": "2026-07-18T15:43:33.745Z",
+            "confidence": 0.9
+          }
+        },
         "panels": {
           "closes": {
             "date": "2026-07-20",

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -25,6 +25,12 @@
             "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mbz3ap4afi2t",
             "asOf": "2026-01-09T18:00:34.831Z",
             "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mqp45coipr23",
+            "asOf": "2026-07-15T16:07:51.941Z",
+            "confidence": 0.9
           }
         },
         "hotel": {

--- a/tails-of-terror.json
+++ b/tails-of-terror.json
@@ -19,6 +19,14 @@
         153.02183549999998
       ],
       "keyDates": {
+        "hotel": {
+          "opens": {
+            "date": "2026-01-30",
+            "source": "https://bsky.app/profile/furdu.com.au/post/3mdmwwknkhk2f",
+            "asOf": "2026-01-30T09:01:46.092Z",
+            "confidence": 0.9
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-04-29",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-19_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**alamo-city-furry-invasion.json** — `alamo-city-furry-invasion-2026` performances.closes → **2026-09-20** (amend 2026-09-24 -> 2026-09-20, conf 0.85)
> Interested in one-on-one dance battles? Sign up for the Dance-Off and face off against other dancers while DJ Hexa hits you with ever-changing music to move to! Sign ups are open now until September 20th! www.furryinvasion.org/event-signups #ACFI2026 📸KiloFoto
> — [source post](https://bsky.app/profile/furryinvasion.bsky.social/post/3mquh742hhc27) at 2026-07-17T19:09:01.977Z
> ⚠️ recency-wins: this replaced **2026-09-24** ([previous post](https://bsky.app/profile/did:plc:i54z3b7sl4jladt3k56ttsoa/post/3mqpwclp3622j), asOf 2026-07-15T23:56:06.478Z) — a different sign-up rather than a correction? `/reject` this date and hand-restore the old one.

**tails-and-tornadoes-fur-con.json** — `tails-and-tornadoes-fur-con-2026` registration.closes → **2026-07-31** (add, conf 0.9)
> Hit the gas and cruise down Route 66 with us—but don't miss your exit! Registration for TTFC 2026 closes at the end of this month. The road is calling, the dinosaurs are waiting, and this is one road trip you won't want to miss. tailsandtornadoes.org/registration/ (artwork by GigaClown)
> — [source post](https://bsky.app/profile/tailsandtornadoes.org/post/3mqp45coipr23) at 2026-07-15T16:07:51.941Z

**tails-of-terror.json** — `tails-of-terror-2026` hotel.opens → **2026-01-30** (add, conf 0.9)
> 🏨 Hotel bookings are NOW LIVE! Book your room at Crowne Plaza Surfers Paradise here: 👉 book.passkey.com/gt/221032278... Rooms are limited and subject to availability. Standard rooms will show at booking, room types assigned later. Good luck! 🤞
> — [source post](https://bsky.app/profile/furdu.com.au/post/3mdmwwknkhk2f) at 2026-01-30T09:01:46.092Z

**furrest-city.json** — `furrest-city-2026` dealers.opens → **2026-07-19** (add, conf 0.9)
> Attention Dealers! Dealers Den applications will open July 19th and close on July 29th. You will find the application on our website furrestcity.org/dealers/
> — [source post](https://bsky.app/profile/did:plc:gs3oxjmihf65m2efx2xu75rr/post/3mqwm6mfids2i) at 2026-07-18T15:43:33.745Z

**furrest-city.json** — `furrest-city-2026` dealers.closes → **2026-07-29** (add, conf 0.9)
> Attention Dealers! Dealers Den applications will open July 19th and close on July 29th. You will find the application on our website furrestcity.org/dealers/
> — [source post](https://bsky.app/profile/did:plc:gs3oxjmihf65m2efx2xu75rr/post/3mqwm6mfids2i) at 2026-07-18T15:43:33.745Z