### PR TITLE
Key dates from Bluesky

### DIFF
--- a/fursquared.json
+++ b/fursquared.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "djs": {
+          "closes": {
+            "date": "2026-10-20",
+            "source": "https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mr3s2ymxn22f",
+            "asOf": "2026-07-20T17:12:13.496Z",
+            "confidence": 0.95
+          }
+        }
+      }
     },
     {
       "id": "fursquared-2026",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-20_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**fursquared.json** — `fursquared-2027` djs.closes → **2026-10-20** (add, conf 0.95)
> The world might be ending; the dance floor shouldn’t. DJ applications for F2K are officially OPEN! Whether you’re spinning nostalgic bangers or enough energy to power us into the next millennium, we want to hear from you. Apply now through Oct 20th: forms.gle/PD71ZvxnRgqG...
> — [source post](https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mr3s2ymxn22f) at 2026-07-20T17:12:13.496Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added closing-date metadata for the FurSquared 2027 DJ submission period.
  * Included the date, source reference, verification timestamp, and confidence information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->