### PR TITLE
Key dates from Bluesky

### DIFF
--- a/biggest-little-fur-con.json
+++ b/biggest-little-fur-con.json
@@ -63,6 +63,14 @@
             "confidence": 0.95
           }
         },
+        "performances": {
+          "opens": {
+            "date": "2026-06-09",
+            "source": "https://bsky.app/profile/did:plc:zkvyhzkfhmrlb5xgthda35fm/post/3mnv75u6tsv2u",
+            "asOf": "2026-06-09T22:02:15.085Z",
+            "confidence": 0.9
+          }
+        },
         "djs": {
           "opens": {
             "date": "2026-04-30",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-20_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**biggest-little-fur-con.json** — `biggest-little-fur-con-2026` performances.opens → **2026-06-09** (add, conf 0.9)
> The Gigantic has been fortified to withstand the fury of your dance moves! Wanna test it out? Entry to the Dance Battle is open goblfc.org/dance-battle/ #BLFC2026
> — [source post](https://bsky.app/profile/did:plc:zkvyhzkfhmrlb5xgthda35fm/post/3mnv75u6tsv2u) at 2026-06-09T22:02:15.085Z

### Refuted by verification (not applied)
- `biggest-little-fur-con-2026` hotel.closes 2026-07-24 — The post refers to a 'Room Drawing' for accommodations, with a deadline to enter on July 24th. This is a hotel lottery or room drawing, not a hotel block bookin

### Skipped — matches an entry in keydates_rejections.json
- `biggest-little-fur-con-2026` panels.opens 2026-05-20 — this date is already in place and the new post just mentions that its already open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the performance registration opening date for Biggest Little Fur Con 2026.
  * Included source, reference date, and confidence details for the new date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->