### PR TITLE
Key dates from Bluesky

### DIFF
--- a/anthro-new-england.json
+++ b/anthro-new-england.json
@@ -27,6 +27,14 @@
             "confidence": 0.95
           }
         },
+        "hotel": {
+          "opens": {
+            "date": "2026-08-22",
+            "source": "https://bsky.app/profile/did:plc:srxungr7qhhxzllfsdfltzau/post/3mrgr7ousy22z",
+            "asOf": "2026-07-25T01:56:14.424Z",
+            "confidence": 0.9
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-07-01",

--- a/anthroexpo.json
+++ b/anthroexpo.json
@@ -17,7 +17,17 @@
       "latLng": [
         35.2434811,
         -97.4786414
-      ]
+      ],
+      "keyDates": {
+        "volunteers": {
+          "opens": {
+            "date": "2026-06-03",
+            "source": "https://bsky.app/profile/did:plc:2yyx6fpki4ibgkmljp6yjtnw/post/3mnfqisoqqo2s",
+            "asOf": "2026-06-03T18:30:00.000Z",
+            "confidence": 0.8
+          }
+        }
+      }
     },
     {
       "id": "anthroexpo-2026",

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -30,6 +30,14 @@
             "confidence": 0.92
           }
         },
+        "hotel": {
+          "opens": {
+            "date": "2026-08-26",
+            "source": "https://bsky.app/profile/did:plc:tcogiehhws3chyw7jvqnozda/post/3mraypilxr22j",
+            "asOf": "2026-07-22T18:54:22.473Z",
+            "confidence": 0.95
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-07-07",

--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -55,6 +55,12 @@
             "source": "https://bsky.app/profile/carolinafurfare.bsky.social/post/3mkyc4v5o6s2n",
             "asOf": "2026-05-03T23:17:48.111Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-08-02",
+            "source": "https://bsky.app/profile/did:plc:eamjvw2tcnvapbkjhbwyuiy7/post/3mrlablcj322k",
+            "asOf": "2026-07-26T20:36:22.867Z",
+            "confidence": 0.9
           }
         },
         "djs": {

--- a/confuror.json
+++ b/confuror.json
@@ -43,6 +43,14 @@
             "asOf": "2026-05-11T22:30:19.452Z",
             "confidence": 0.9
           }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-08-22",
+            "source": "https://bsky.app/profile/did:plc:sj3gp6suyjokm32gk7swrfcd/post/3mrgkq352ls2i",
+            "asOf": "2026-07-25T00:00:07.956Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/denfur.json
+++ b/denfur.json
@@ -41,6 +41,12 @@
             "source": "https://bsky.app/profile/denfur.org/post/3mdgh3uujje2h",
             "asOf": "2026-01-27T11:02:26-08:00",
             "confidence": 0.85
+          },
+          "closes": {
+            "date": "2026-08-02",
+            "source": "https://bsky.app/profile/did:plc:5qadfstdsv7yd2nvezahdlxq/post/3mrlewmwqgv2x",
+            "asOf": "2026-07-26T21:59:44.087Z",
+            "confidence": 0.9
           }
         },
         "panels": {
@@ -48,6 +54,14 @@
             "date": "2026-07-10",
             "source": "https://bsky.app/profile/denfur.org/post/3mq7xlci6ss2b",
             "asOf": "2026-07-09T15:36:16.732Z",
+            "confidence": 0.9
+          }
+        },
+        "performances": {
+          "closes": {
+            "date": "2026-08-13",
+            "source": "https://bsky.app/profile/did:plc:5qadfstdsv7yd2nvezahdlxq/post/3mri436xigs2h",
+            "asOf": "2026-07-25T14:43:14.416Z",
             "confidence": 0.9
           }
         }

--- a/furgeddaboutit.json
+++ b/furgeddaboutit.json
@@ -20,7 +20,17 @@
       ],
       "sources": [
         "fancons.com"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/did:plc:jjrjjs24paafnoncv2gg3dvv/post/3mqif7yur6s2x",
+            "asOf": "2026-07-13T00:01:47.853Z",
+            "confidence": 0.8
+          }
+        }
+      }
     },
     {
       "id": "furgeddaboutit-2026",

--- a/furpocalypse.json
+++ b/furpocalypse.json
@@ -27,6 +27,14 @@
             "confidence": 0.9
           }
         },
+        "hotel": {
+          "opens": {
+            "date": "2026-08-15",
+            "source": "https://bsky.app/profile/did:plc:azcrwj7meawnegprye7h3j2e/post/3mrghelbjwj2k",
+            "asOf": "2026-07-24T23:00:00.670Z",
+            "confidence": 0.9
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-06-07",

--- a/furry-migration.json
+++ b/furry-migration.json
@@ -50,11 +50,25 @@
           }
         },
         "panels": {
+          "opens": {
+            "date": "2026-05-07",
+            "source": "https://bsky.app/profile/did:plc:ittzfj5vrjmgupumwkws36dv/post/3mlbz2wepql2j",
+            "asOf": "2026-05-07T20:02:15.955Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-07-11",
             "source": "https://bsky.app/profile/furrymigration.org/post/3mo47s6dk6c2w",
             "asOf": "2026-06-12T17:02:14.978Z",
             "confidence": 0.85
+          }
+        },
+        "performances": {
+          "opens": {
+            "date": "2026-07-21",
+            "source": "https://bsky.app/profile/did:plc:ittzfj5vrjmgupumwkws36dv/post/3mr6bxj3jra2c",
+            "asOf": "2026-07-21T17:01:55.813Z",
+            "confidence": 0.9
           }
         },
         "djs": {

--- a/fursquared.json
+++ b/fursquared.json
@@ -22,7 +22,21 @@
         "fancons.com"
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mrslzxilic2f",
+            "asOf": "2026-07-29T18:55:30.285Z",
+            "confidence": 0.9
+          }
+        },
         "djs": {
+          "opens": {
+            "date": "2026-07-20",
+            "source": "https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mr3s2ymxn22f",
+            "asOf": "2026-07-20T17:12:13.496Z",
+            "confidence": 0.9
+          },
           "closes": {
             "date": "2026-10-20",
             "source": "https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mr3s2ymxn22f",

--- a/infurnity.json
+++ b/infurnity.json
@@ -28,6 +28,14 @@
         "fancons.com"
       ],
       "keyDates": {
+        "registration": {
+          "closes": {
+            "date": "2026-09-10",
+            "source": "https://bsky.app/profile/did:plc:uiqsmywrawljvwhmia6odqcs/post/3mrhoicf55k2s",
+            "asOf": "2026-07-25T10:40:01.830Z",
+            "confidence": 0.9
+          }
+        },
         "hotel": {
           "opens": {
             "date": "2026-06-01",

--- a/tails-of-summer.json
+++ b/tails-of-summer.json
@@ -24,10 +24,10 @@
       "keyDates": {
         "registration": {
           "closes": {
-            "date": "2026-07-27",
-            "source": "https://bsky.app/profile/tailsofsummer.com/post/3mo72d6ubuv2m",
-            "asOf": "2026-06-13T20:02:22.571Z",
-            "confidence": 0.95
+            "date": "2026-07-24",
+            "source": "https://bsky.app/profile/did:plc:dn7cq63ck4j5fgdhdn36qamz/post/3mr6hprn5li2x",
+            "asOf": "2026-07-21T18:44:58.822Z",
+            "confidence": 0.8
           }
         },
         "hotel": {

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -44,6 +44,12 @@
             "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mq7rc2zwms26",
             "asOf": "2026-07-09T13:43:44.467Z",
             "confidence": 0.95
+          },
+          "closes": {
+            "date": "2026-09-13",
+            "source": "https://bsky.app/profile/did:plc:syftgxeqo6hbgi34cyigzkq3/post/3mrb7lahwz22g",
+            "asOf": "2026-07-22T20:57:15.911Z",
+            "confidence": 0.95
           }
         }
       }


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-30_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**furry-migration.json** — `furry-migration-2026` performances.opens → **2026-07-21** (add, conf 0.9)
> Are you wanting to shake your tail, paws, wings and everything in between? The #FurryMigration 2026 Fursuit Dance Comp & Dance Battle applications are now live! www.furrymigration.org/events/fursu... Come join the show and cheer on your friends! 📸: NAUTA
> — [source post](https://bsky.app/profile/did:plc:ittzfj5vrjmgupumwkws36dv/post/3mr6bxj3jra2c) at 2026-07-21T17:01:55.813Z

**furry-migration.json** — `furry-migration-2026` panels.opens → **2026-05-07** (add, conf 0.9)
> Do you love being the center of attention, sharing your passion, or want to help build up your community? We've got a mad gnarly opportunity: submit your panel ideas for #FurryMigration 2026! You've only got until July 17th, so you'd better book it! www.furrymigration.org/events/panels/
> — [source post](https://bsky.app/profile/did:plc:ittzfj5vrjmgupumwkws36dv/post/3mlbz2wepql2j) at 2026-05-07T20:02:15.955Z

**tails-of-summer.json** — `tails-of-summer-2026` registration.closes → **2026-07-24** (amend 2026-07-27 -> 2026-07-24, conf 0.8)
> With 3 days until pre-reg closes, pre-ordering food event tickets and merch goes away then as well! These are all limited ticket sales, and merch not guaranteed at-con! Get your Munch Bruch tickets as well as Sundae Social, merch orders and more at tailsofsummer.com/registration/ Info in comment!
> — [source post](https://bsky.app/profile/did:plc:dn7cq63ck4j5fgdhdn36qamz/post/3mr6hprn5li2x) at 2026-07-21T18:44:58.822Z
> ⚠️ recency-wins: this replaced **2026-07-27** ([previous post](https://bsky.app/profile/tailsofsummer.com/post/3mo72d6ubuv2m), asOf 2026-06-13T20:02:22.571Z) — a different sign-up rather than a correction? `/reject` this date and hand-restore the old one.

**capital-fur-con.json** — `capital-fur-con-2027` hotel.opens → **2026-08-26** (add, conf 0.95)
> GIRLS AND SWIRLS ITS TIME 4... ROOM BLOCK !!!! ROOM BLOCK!!!🤯‼️ AWOOOGA!!!🔥 🚨RED ALERT !! 🚨 SIGN UPS FOR SUPER SPONSORS AND DONORS: -> AUGUST 12 <- REGULAR ROOM BLOCK FOR ATTENDEES: -> AUGUST 26 <- REMBER: YOU MUST BE REGISTERED TO SIGN UP!! #CAPITALFURCON #CFC2027 #FURRY
> — [source post](https://bsky.app/profile/did:plc:tcogiehhws3chyw7jvqnozda/post/3mraypilxr22j) at 2026-07-22T18:54:22.473Z

**western-pa-furry-weekend.json** — `western-pa-furry-weekend-2026` panels.closes → **2026-09-13** (add, conf 0.95)
> Would you like to share your deep passion for AMV lore? Want to teach people how to play your favorite board game? How about a fox figure study? Send your ideas over to our panel submissions, open until September 13th! Submit your panels here: wpafw.org/event-info/p...
> — [source post](https://bsky.app/profile/did:plc:syftgxeqo6hbgi34cyigzkq3/post/3mrb7lahwz22g) at 2026-07-22T20:57:15.911Z

**furpocalypse.json** — `furpocalypse-2026` hotel.opens → **2026-08-15** (add, conf 0.9)
> 🏨 SPECIAL ANNOUNCMENT LIVE VIA FURPOC RADIO 🏨 Hotel rooming reservations will be going LIVE August 15th at 12pm ET for The DoubleTree Stamford and 12:30pm ET for our official partner overflow, The Hyatt Regency Greenwich.
> — [source post](https://bsky.app/profile/did:plc:azcrwj7meawnegprye7h3j2e/post/3mrghelbjwj2k) at 2026-07-24T23:00:00.670Z

**confuror.json** — `confuror-2026` panels.closes → **2026-08-22** (add, conf 0.9)
> 📣 Panels and Activities Submissions - Confuror 2026 Do you have a burning passion, an idea you'd like to share, or a talent you'd like to teach? Send your proposal for a panel or event you'd like to host this year! 📅 Open until August 22 🌐 Info: confuror.org/en/panels/ 🎨: @shinxxtatts.bsky.social
> — [source post](https://bsky.app/profile/did:plc:sj3gp6suyjokm32gk7swrfcd/post/3mrgkq352ls2i) at 2026-07-25T00:00:07.956Z

**anthro-new-england.json** — `anthro-new-england-2027` hotel.opens → **2026-08-22** (add, conf 0.9)
> Hey folks! We'll put out an official post, but for now: @ane.boston has NOT opened any hotel blocks for 2027! The main hotels open Aug 22 for attendees. Vendors who are selected will be sent a booking link via email after selections are completed. Please ignore ANY emails looking like this:
> — [source post](https://bsky.app/profile/did:plc:srxungr7qhhxzllfsdfltzau/post/3mrgr7ousy22z) at 2026-07-25T01:56:14.424Z

**furgeddaboutit.json** — `furgeddaboutit-2027` registration.opens → **2026-07-31** (add, conf 0.8)
> Do you wanna be apart of “This Furry Thing Of Ours?” If you answered yes the Don has good news for you. Pre-Registration Opens July 31. If you answered no the Don would like to have a few words with you. Capeesh?
> — [source post](https://bsky.app/profile/did:plc:jjrjjs24paafnoncv2gg3dvv/post/3mqif7yur6s2x) at 2026-07-13T00:01:47.853Z

**infurnity.json** — `infurnity-2026` registration.closes → **2026-09-10** (add, conf 0.9)
> 【 #INFURNITY2026 | Transmission】 …Countdown protocol initiated… Application and submission deadlines are approaching. Please verify that all assigned tasks have been completed. ⏰ Deadline: www.infurnity.com/en/2026/07/d... ⏳ Reg Deadline: SEP. 10 www.infurnity.com/en/reginfo-en/ 【END TRANSMISSION】
> — [source post](https://bsky.app/profile/did:plc:uiqsmywrawljvwhmia6odqcs/post/3mrhoicf55k2s) at 2026-07-25T10:40:01.830Z

**denfur.json** — `denfur-2026` performances.closes → **2026-08-13** (add, conf 0.9)
> #DenFur Dance Competition sign ups close August 13th! Let's see your skills! denfur.org/apply/dance-...
> — [source post](https://bsky.app/profile/did:plc:5qadfstdsv7yd2nvezahdlxq/post/3mri436xigs2h) at 2026-07-25T14:43:14.416Z

**anthroexpo.json** — `anthroexpo-2027` volunteers.opens → **2026-06-03** (add, conf 0.8)
> Calling all folks who would be interested in helping us make AnthroExpo 2027 better than ever! We currently have several open positions, including art production, graphic design, social media, training, and more! Check out the link below and find a good role for you!
> — [source post](https://bsky.app/profile/did:plc:2yyx6fpki4ibgkmljp6yjtnw/post/3mnfqisoqqo2s) at 2026-06-03T18:30:00.000Z

**fursquared.json** — `fursquared-2027` djs.opens → **2026-07-20** (add, conf 0.9)
> The world might be ending; the dance floor shouldn’t. DJ applications for F2K are officially OPEN! Whether you’re spinning nostalgic bangers or enough energy to power us into the next millennium, we want to hear from you. Apply now through Oct 20th: forms.gle/PD71ZvxnRgqG...
> — [source post](https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mr3s2ymxn22f) at 2026-07-20T17:12:13.496Z

**denfur.json** — `denfur-2026` dealers.closes → **2026-08-02** (add, conf 0.9)
> #PDFC Our dealers den applications have been extended until 8/2 so if your forgot to apply, you have one last chance! https://painteddesertfc.org/apply/dealers-den/ 🖍️: Eaglidots
> — [source post](https://bsky.app/profile/did:plc:5qadfstdsv7yd2nvezahdlxq/post/3mrlewmwqgv2x) at 2026-07-26T21:59:44.087Z

**carolina-furfare.json** — `carolina-furfare-2026` panels.closes → **2026-08-02** (add, conf 0.9)
> Tick tock, researchers! One week remains to apply to host a panel at Carolina Furfare. Share your passion and wisdom before the portal closes! 👁️ www.carolinafurfare.org/schedule
> — [source post](https://bsky.app/profile/did:plc:eamjvw2tcnvapbkjhbwyuiy7/post/3mrlablcj322k) at 2026-07-26T20:36:22.867Z

**fursquared.json** — `fursquared-2027` registration.opens → **2026-07-31** (add, conf 0.9)
> F2_Admin has signed on. F2_Admin: hey F2_Admin: apparently the world might be ending at midnight F2_Admin: anyway... F2_Admin: wanna RSVP for our party of a lifetime? Registration opens July 31st at 1pm CDT ✨
> — [source post](https://bsky.app/profile/did:plc:2s3t7hs6j3uqosgcgbueegac/post/3mrslzxilic2f) at 2026-07-29T18:55:30.285Z

### Refuted by verification (not applied)
- `anthro-weekend-utah-2026` dealers.closes 2026-02-14 — The post says "Dealers' Den and Artist Alley applications for AWU 2026 CLOSE SOON. Submit your application by tomorrow at midnight...". The post timestamp is 20
- `anthro-weekend-utah-2026` dealers.closes 2026-02-14 — The post states that applications for Dealers' Den and Artist Alley will close after 11:59pm MST on February 13th. Thus, the closing occurs at the end of Februa
- `anthro-weekend-utah-2026` volunteers.opens 2026-05-26 — The post indicates that AWU is looking for more volunteers on the specified date, but it does not state that this is the opening date for volunteer registration
- `anthro-weekend-utah-2026` registration.closes 2026-05-23 — The post specifies only an upper-tier (Ultimate) registration closing after May 22nd, not a hard close for general attendee registration. Special tier closes do
- `anthro-weekend-utah-2026` panels.closes 2026-07-12 — The post says "Panel applications will close after Saturday, July 11th". July 11th, 2026 is a Saturday; so the close occurs at the end of that day, not July 12t
- `anthro-weekend-utah-2026` performances.closes 2026-07-25 — The post states "Signups on MyAWU will close after July 24th" for the Fursuit Dance Competition, which falls under "performances" and means closing at the end o
- `anthro-weekend-utah-2026` hotel.opens 2026-03-20 — The post, timestamped March 21, announces the opening of the Alpha/Dealer hotel lottery saying it is now open, without specifying March 20. The opening occurs u
- `anthro-weekend-utah-2026` hotel.closes 2026-03-27 — The post states that the hotel lottery is closing after Friday, 3/27. However, per category strictness, hotel room lotteries are not considered the same as the 