### PR TITLE
Updated for Vancoufur 2027

### DIFF
--- a/vancoufur.json
+++ b/vancoufur.json
@@ -6,6 +6,20 @@
   },
   "events": [
     {
+      "id": "vancoufur-2027",
+      "name": "VancouFur 2027",
+      "url": "https://vancoufur.org",
+      "startDate": "2027-03-04",
+      "endDate": "2027-03-07",
+      "venue": "Richmond Conference Centre",
+      "address": "7551 Westminster Hwy, Richmond, BC V6X 1A3, Canada",
+      "locale": "en-CA",
+      "latLng": [
+        49.1709306,
+        -123.1416696
+      ]
+    },
+    {
       "id": "vancoufur-2026",
       "name": "VancouFur 2026",
       "url": "https://vancoufur.org",


### PR DESCRIPTION
Website contains enough information for their next event in 2027 to fill this out now.
Ensured this time all the dates and name are correct. You are also able to register for the convention already. But no details yet for when panels/etc are going to be open.

https://vancoufur.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VancouFur 2027 to the event listings.
  * Included event dates, venue, location, website, and map coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->