### PR TITLE
Fix keydates_reject dropping batched /reject comments

### DIFF
--- a/.github/scripts/keydates_reject.py
+++ b/.github/scripts/keydates_reject.py
@@ -100,10 +100,12 @@ def main() -> int:
             if git("push", check=False).returncode == 0:
                 print("ok", end="")
                 return 0
-        except (subprocess.CalledProcessError, OSError, json.JSONDecodeError):
-            pass  # any git / IO / parse error this attempt — back off, retry
-            # (a corrupt or missing rejections file loops to push-failure so
-            # the commenter still gets a 👎, rather than crashing silently)
+        except (subprocess.CalledProcessError, OSError, json.JSONDecodeError) as e:
+            # stdout is the sentinel channel, so log the swallowed error to
+            # stderr — an exhausted loop is then diagnosable (which step, why).
+            # A corrupt/missing rejections file loops to push-failure so the
+            # commenter still gets a 👎 rather than a silent crash.
+            print(f"reject attempt {attempt} failed: {e!r}", file=sys.stderr)
         # jitter so near-simultaneous losers don't retry in lockstep
         # (skip after the final attempt — no point sleeping before we give up)
         if attempt < 24:

--- a/.github/scripts/keydates_reject.py
+++ b/.github/scripts/keydates_reject.py
@@ -12,9 +12,11 @@ Example: /reject anthrocon-2026 registration.closes 2026-06-26 — that's the pr
 import datetime
 import json
 import os
+import random
 import re
 import subprocess
 import sys
+import time
 
 # (?!\S) forces the date to end at whitespace/end-of-comment: without it,
 # a typo like 2026-07-125 matched as date 2026-07-12 with the stray "5"
@@ -25,6 +27,8 @@ GRAMMAR = re.compile(
     r"(\d{4}-\d{2}-\d{2})(?!\S)\s*(?:[—–-]+\s*)?(.*)$",
     re.S,
 )
+
+REJECTIONS_FILE = ".github/keydates_rejections.json"
 
 def parse(body):
     """Parse a /reject comment. Returns (fields, None) or (None, error)."""
@@ -50,9 +54,6 @@ def main() -> int:
     event_id, category, kind, date, reason = fields
     reason = " ".join(reason.split())[:300]  # collapse whitespace, cap length
 
-    with open(".github/keydates_rejections.json") as f:
-        rejections = json.load(f)
-
     entry = {
         "event_id": event_id,
         "category": category,
@@ -62,35 +63,56 @@ def main() -> int:
         "by": user,
         "at": created,
     }
-    if any(
-        all(r.get(k) == entry[k] for k in ("event_id", "category", "kind", "date"))
-        for r in rejections
-    ):
-        print("duplicate", end="")
-        return 0
-
-    rejections.append(entry)
-    with open(".github/keydates_rejections.json", "w") as f:
-        json.dump(rejections, f, indent=2, ensure_ascii=False)
-        f.write("\n")
 
     # our stdout is captured into $GITHUB_OUTPUT — only the sentinel word may
     # reach it, so route every git subprocess's stdout to stderr
     def git(*args, check=True):
         return subprocess.run(["git", *args], check=check, stdout=sys.stderr)
 
-    git("config", "user.name", "cons.fyi GitHub bot")
-    git("config", "user.email", "github@cons.fyi")
-    git("add", ".github/keydates_rejections.json")
-    git("commit", "-m", f"Reject key date {event_id} {category}.{kind} {date}")
-    # two racing /reject comments: rebase and retry the push
-    for _ in range(3):
-        if git("push", check=False).returncode == 0:
-            print("ok", end="")
-            return 0
-        git("pull", "--rebase")
+    key = ("event_id", "category", "kind", "date")
+    # Batched /reject comments now run in parallel (one concurrency group per
+    # comment id), so serialize at the git layer: on every attempt re-sync to
+    # the latest origin/main, then dedup + append against THAT and push. We
+    # RECOMPUTE the append each time rather than rebasing our own commit —
+    # two runs appending to the same JSON array would otherwise conflict on
+    # rebase or clobber each other's entry.
+    # Budget must cover the worst case where N racing runners each need their
+    # own attempt to win the push; 25 is generous headroom over observed batch
+    # sizes. A transient git error (fetch/reset/add/commit) is caught and
+    # counted as a failed attempt rather than crashing without a sentinel.
+    for attempt in range(25):
+        try:
+            git("config", "user.name", "cons.fyi GitHub bot")
+            git("config", "user.email", "github@cons.fyi")
+            git("fetch", "origin", "main")
+            git("reset", "--hard", "origin/main")
+            with open(REJECTIONS_FILE) as f:
+                rejections = json.load(f)
+            if any(all(r.get(k) == entry[k] for k in key) for r in rejections):
+                print("duplicate", end="")
+                return 0
+            rejections.append(entry)
+            with open(REJECTIONS_FILE, "w") as f:
+                json.dump(rejections, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            git("add", REJECTIONS_FILE)
+            git("commit", "-m", f"Reject key date {event_id} {category}.{kind} {date}")
+            if git("push", check=False).returncode == 0:
+                print("ok", end="")
+                return 0
+        except (subprocess.CalledProcessError, OSError, json.JSONDecodeError):
+            pass  # any git / IO / parse error this attempt — back off, retry
+            # (a corrupt or missing rejections file loops to push-failure so
+            # the commenter still gets a 👎, rather than crashing silently)
+        # jitter so near-simultaneous losers don't retry in lockstep
+        # (skip after the final attempt — no point sleeping before we give up)
+        if attempt < 24:
+            time.sleep(0.5 * (attempt + 1) + random.uniform(0, 0.5))
+    # Exhausted: emit the sentinel but exit 0 so the Record step succeeds and
+    # the React step still runs to post feedback (exit 1 would skip it, which
+    # is the silent-drop bug this loop fixes).
     print("push-failure", end="")
-    return 1
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/.github/scripts/test_keydates_reject.py
+++ b/.github/scripts/test_keydates_reject.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
-"""Unit tests for the /reject comment parser. Run directly:
+"""Unit tests for the /reject comment parser and record loop. Run directly:
 python3 .github/scripts/test_keydates_reject.py"""
+import contextlib
+import io
+import json
+import os
+import subprocess
+import tempfile
+import types
 import unittest
+import unittest.mock
 
+import keydates_reject
 from keydates_reject import parse
 
 
@@ -50,6 +59,133 @@ class TestParse(unittest.TestCase):
     def test_garbage(self):
         fields, err = parse("/reject please")
         self.assertEqual(err, "parse-failure")
+
+
+class FakeGit:
+    """Stands in for `subprocess.run(["git", ...])`. Models origin/main as an
+    in-memory list: `reset --hard origin/main` rewrites the working file to it
+    (optionally growing it first, to mimic another run landing between
+    attempts); a successful `push` promotes the working file to origin/main."""
+
+    def __init__(self, tmpfile, remote, push_rc, grow_on_reset=(), raise_first=None,
+                 corrupt=False):
+        self.tmpfile = tmpfile
+        self.remote = list(remote)
+        self.push_rc = list(push_rc)
+        self.grow = list(grow_on_reset)
+        self.reset_count = 0
+        self.calls = []
+        self.raise_first = raise_first   # subcommand to raise on, once
+        self._raised = False
+        self.corrupt = corrupt           # reset writes invalid JSON (bad file on main)
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(argv)
+        sub = argv[1] if len(argv) > 1 else ""
+        if sub == self.raise_first and not self._raised:
+            self._raised = True          # simulate one transient git failure
+            raise subprocess.CalledProcessError(1, argv)
+        rc = 0
+        if sub == "reset":
+            self.reset_count += 1
+            if self.reset_count >= 2 and self.grow:   # a rival run landed
+                self.remote.append(self.grow.pop(0))
+            with open(self.tmpfile, "w") as f:
+                if self.corrupt:
+                    f.write("{ not valid json")
+                else:
+                    json.dump(self.remote, f)
+        elif sub == "push":
+            rc = self.push_rc.pop(0) if self.push_rc else 0
+            if rc == 0:
+                with open(self.tmpfile) as f:
+                    self.remote = json.load(f)   # our append is now on main
+        return types.SimpleNamespace(returncode=rc)
+
+    def subs(self):
+        return [c[1] for c in self.calls if len(c) > 1]
+
+
+class TestRecord(unittest.TestCase):
+    ENV = {
+        "COMMENT_BODY": "/reject anthrocon-2026 registration.closes 2026-06-26 — pre-reg deadline",
+        "COMMENT_USER": "sparkyfen",
+        "COMMENT_CREATED_AT": "2026-07-27T00:00:00Z",
+    }
+
+    def _run(self, remote, push_rc, grow_on_reset=(), raise_first=None, corrupt=False):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        with open(path, "w") as f:
+            json.dump(remote, f)
+        self.addCleanup(os.unlink, path)
+        fake = FakeGit(path, remote, push_rc, grow_on_reset, raise_first, corrupt)
+        out = io.StringIO()
+        with unittest.mock.patch.object(keydates_reject, "REJECTIONS_FILE", path), \
+             unittest.mock.patch.object(keydates_reject.subprocess, "run", fake), \
+             unittest.mock.patch.object(keydates_reject.time, "sleep", lambda *_: None), \
+             unittest.mock.patch.dict(os.environ, self.ENV, clear=True), \
+             contextlib.redirect_stdout(out):
+            rc = keydates_reject.main()
+        with open(path) as f:
+            try:
+                final = json.load(f)       # None if the run left it corrupt
+            except json.JSONDecodeError:
+                final = None
+        return rc, out.getvalue(), final, fake
+
+    def test_happy_path_appends_and_pushes(self):
+        rc, sentinel, final, fake = self._run(remote=[], push_rc=[0])
+        self.assertEqual((rc, sentinel), (0, "ok"))
+        self.assertEqual([(r["event_id"], r["category"], r["kind"], r["date"]) for r in final],
+                         [("anthrocon-2026", "registration", "closes", "2026-06-26")])
+        self.assertIn("push", fake.subs())
+
+    def test_push_race_recomputes_against_fresh_main(self):
+        # first push loses the race; a rival reject ("other") landed meanwhile.
+        # The retry must re-read origin/main and re-append OURS on top of it —
+        # not clobber the rival, not duplicate ourselves.
+        other = {"event_id": "x-2026", "category": "hotel", "kind": "opens",
+                 "date": "2026-01-01", "reason": "r", "by": "u", "at": "t"}
+        rc, sentinel, final, fake = self._run(
+            remote=[], push_rc=[1, 0], grow_on_reset=[other])
+        self.assertEqual((rc, sentinel), (0, "ok"))
+        keys = [(r["event_id"], r["category"], r["kind"], r["date"]) for r in final]
+        self.assertIn(("x-2026", "hotel", "opens", "2026-01-01"), keys)          # rival preserved
+        self.assertEqual(keys.count(("anthrocon-2026", "registration", "closes", "2026-06-26")), 1)  # ours once
+        self.assertEqual(fake.subs().count("push"), 2)                            # retried
+
+    def test_duplicate_after_resync_does_not_push(self):
+        dup = {"event_id": "anthrocon-2026", "category": "registration", "kind": "closes",
+               "date": "2026-06-26", "reason": "already", "by": "someone", "at": "earlier"}
+        rc, sentinel, final, fake = self._run(remote=[dup], push_rc=[0])
+        self.assertEqual((rc, sentinel), (0, "duplicate"))
+        self.assertEqual(len(final), 1)                 # not re-appended
+        self.assertNotIn("push", fake.subs())           # nothing pushed
+
+    def test_retry_exhaustion_emits_sentinel_and_exits_zero(self):
+        # every push loses the race: still return the sentinel + exit 0 so the
+        # React step runs and posts feedback (exit 1 would silently drop it).
+        rc, sentinel, final, fake = self._run(remote=[], push_rc=[1] * 25)
+        self.assertEqual((rc, sentinel), (0, "push-failure"))
+        self.assertEqual(fake.subs().count("push"), 25)
+
+    def test_corrupt_rejections_file_fails_soft_not_silent(self):
+        # a corrupt keydates_rejections.json on main makes json.load raise every
+        # attempt; the loop must NOT crash silently — it emits push-failure and
+        # exits 0 so the React step still posts a 👎 (the whole point of the fix).
+        rc, sentinel, final, fake = self._run(remote=[], push_rc=[0], corrupt=True)
+        self.assertEqual((rc, sentinel), (0, "push-failure"))
+        self.assertNotIn("push", fake.subs())   # never got far enough to push
+
+    def test_transient_git_error_recovers_on_later_attempt(self):
+        # the first `fetch` blows up with a CalledProcessError; the loop must
+        # catch it, back off, and still record the reject on a later attempt.
+        rc, sentinel, final, fake = self._run(
+            remote=[], push_rc=[0], raise_first="fetch")
+        self.assertEqual((rc, sentinel), (0, "ok"))
+        keys = [(r["event_id"], r["category"], r["kind"], r["date"]) for r in final]
+        self.assertIn(("anthrocon-2026", "registration", "closes", "2026-06-26"), keys)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_keydates_reject.py
+++ b/.github/scripts/test_keydates_reject.py
@@ -176,7 +176,9 @@ class TestRecord(unittest.TestCase):
         # exits 0 so the React step still posts a 👎 (the whole point of the fix).
         rc, sentinel, final, fake = self._run(remote=[], push_rc=[0], corrupt=True)
         self.assertEqual((rc, sentinel), (0, "push-failure"))
-        self.assertNotIn("push", fake.subs())   # never got far enough to push
+        self.assertNotIn("push", fake.subs())        # never got far enough to push
+        self.assertIsNone(final)                     # file stayed corrupt, never repaired
+        self.assertEqual(fake.subs().count("fetch"), 25)  # retried every attempt
 
     def test_transient_git_error_recovers_on_later_attempt(self):
         # the first `fetch` blows up with a CalledProcessError; the loop must

--- a/.github/workflows/keydates_reject.yml
+++ b/.github/workflows/keydates_reject.yml
@@ -15,8 +15,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# One group PER COMMENT, not a shared group: GitHub keeps only a single
+# pending run per group and cancels the rest, so a shared group silently drops
+# all but the first + last of a batch of /reject comments. Per-comment groups
+# let every reject run; keydates_reject.py serializes the actual push by
+# recomputing its append against fresh origin/main on each retry.
 concurrency:
-  group: keydates-reject
+  group: keydates-reject-${{ github.event.comment.id }}
   cancel-in-progress: false
 
 jobs:
@@ -63,6 +68,8 @@ jobs:
             content="-1"
             if [ "$RESULT" = "invalid-date" ]; then
               msg="That date isn't a real calendar date. Syntax: \`/reject <event_id> <category>.<kind> <YYYY-MM-DD> — <reason>\`"
+            elif [ "$RESULT" = "push-failure" ]; then
+              msg="Couldn't record that reject right now (write contention on the rejections file). Please re-comment \`/reject …\` to retry."
             else
               msg="Could not parse that. Syntax: \`/reject <event_id> <category>.<kind> <YYYY-MM-DD> — <reason>\`"
             fi


### PR DESCRIPTION
## Problem
A shared GitHub Actions `concurrency` group (`group: keydates-reject`, `cancel-in-progress: false`) keeps only **one** pending run per group and cancels the rest. So when several `/reject` comments are posted in a batch — exactly what reviewing a bad bot PR invites — GitHub runs the first, keeps the last as the single pending run, and **silently cancels everything in between**. Observed live: a 9-comment batch → first + last recorded, **7 silently dropped** (no 👎, no feedback).

## Fix
- **`.github/workflows/keydates_reject.yml`** — concurrency group is now **per-comment** (`keydates-reject-${{ github.event.comment.id }}`), so no run is ever superseded/cancelled; every `/reject` runs.
- **`.github/scripts/keydates_reject.py`** — since runs are now parallel, the push is serialized at the git layer: each attempt re-syncs to fresh `origin/main` and **recomputes** the dedup + append against it (rather than `git pull --rebase`, which conflicts when two runs append to the same JSON array), retrying up to **25×** with jittered backoff. All git/IO/parse work is wrapped so any per-attempt failure (git error, corrupt/missing file) backs off and retries. On exhaustion it prints the `push-failure` sentinel and **exits 0**, so the Record step succeeds and the **React step still posts a 👎** with a re-comment hint — exiting non-zero would skip React, which is the exact silent-drop shape this fixes.
- **React step** — distinct `push-failure` message telling the commenter to re-comment.

The `issue_comment` hardening from the prior security review is untouched: login allowlist, `bot/bsky-keydates` head-ref gate, and env-only handling of the comment body.

## Tests
`python3 .github/scripts/test_keydates_reject.py` — 13 pass. FakeGit race simulation covers: happy path, push-race recompute (no clobber / no duplicate), duplicate-after-resync, retry exhaustion → sentinel + exit 0, transient-git-error recovery, and corrupt-file-fails-soft. Runs in CI via `validate.yml`.

## Note
This only takes effect once merged — the workflow runs from `main`. Found and fixed after a batch of 9 `/reject` comments lost 7 to this bug (recovered manually by re-running the cancelled workflows one at a time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/reject` handling for simultaneous comments by isolating runs per comment.
  * Prevented duplicate rejection entries and reduced the risk of overwriting existing data when syncing.
  * Added stronger protection against corrupted or unreadable rejection storage, avoiding unintended updates.

* **Reliability**
  * Added automatic retries with resynchronization to handle temporary save and synchronization issues.
  * Enhanced the reaction message with a dedicated “push-failure” outcome when recording cannot be completed after repeated attempts.
  * Ensured downstream workflow reactions still proceed even when saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->