### PR TITLE
Key dates from Bluesky

### DIFF
--- a/aquatifur.json
+++ b/aquatifur.json
@@ -33,6 +33,12 @@
             "source": "https://bsky.app/profile/aquatifur.com/post/3mplyvivyxk26",
             "asOf": "2026-07-01T17:06:37.996Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/did:plc:efgqcoutfj3rxzkeihyaz26q/post/3mruxbakpqh2l",
+            "asOf": "2026-07-30T17:21:45.202Z",
+            "confidence": 0.9
           }
         },
         "panels": {


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-4.1-mini` · Verify (unanimous): `openai/gpt-4.1` + `openai/gpt-4o` · 2026-07-30_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**aquatifur.json** — `aquatifur-2026` dealers.closes → **2026-07-31** (add, conf 0.9)
> #AQF has the following applications closing tomorrow! - Artist Alley - DJ https://aquatifur.org 🎨 Eaglidots
> — [source post](https://bsky.app/profile/did:plc:efgqcoutfj3rxzkeihyaz26q/post/3mruxbakpqh2l) at 2026-07-30T17:21:45.202Z