### PR TITLE
aquatifur-2026: add missing djs.closes 2026-07-31

### DIFF
--- a/aquatifur.json
+++ b/aquatifur.json
@@ -49,6 +49,14 @@
             "confidence": 0.9
           }
         },
+        "djs": {
+          "closes": {
+            "date": "2026-07-31",
+            "source": "https://bsky.app/profile/did:plc:efgqcoutfj3rxzkeihyaz26q/post/3mruxbakpqh2l",
+            "asOf": "2026-07-30T17:21:45.202Z",
+            "confidence": 0.9
+          }
+        },
         "volunteers": {
           "opens": {
             "date": "2026-07-14",


### PR DESCRIPTION
Follow-up to #65.

The 2026-07-30 aquatifur announcement listed **two** application types closing 2026-07-31:
> #AQF has the following applications closing tomorrow! - Artist Alley - DJ

The bot sweep (#65) mapped only the Artist Alley half to `dealers.closes` and silently dropped the DJ half. This adds the missing `djs.closes → 2026-07-31` on `aquatifur-2026` (same source post, asOf, confidence 0.9 as the dealers entry).

The extractor-side conflation is tracked in Linear CON-31 as a prompt-hardening eval case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dealer and dance DJ closing-date information for AquatiFur 2026.
  * Includes the date, source, timestamp, and confidence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->