### PR TITLE
furdu no longer uses EventDrake

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Attribution is not required but appreciated. This helps us keep our data up to d
 - The majority of data is imported from [FanCons.com](https://fancons.com) and is annotated as such. Usage restrictions may apply.
 - Your convention may be able to be automatically imported. Automatic import is supported (to varying degrees) for the following registration systems:
   - [ConCat](https://concat.app)
-  - [EventDrake](https://eventdrake.net) (including Aurawra, FurCoNZ, FurDU)
+  - [EventDrake](https://eventdrake.net) (including Aurawra, FurCoNZ)
   - [RAMS](https://reg.furfest.org) (Midwest FurFest only)
 - If you would like data.cons.fyi to automatically import your convention, please [file an issue](https://github.com/consfyi/data/issues/new?template=add-convention.yml) for convention listing. Please provide details on how event dates and venue information can be imported from your registration system, or if you are already using one of the supported registration systems.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the data sources documentation to remove FurDU from the EventDrake automatic-import listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->