### PR TITLE
Add Michigan Anthro Weekend

### DIFF
--- a/michigan-anthro-weekend.json
+++ b/michigan-anthro-weekend.json
@@ -1,0 +1,23 @@
+{
+  "name": "Michigan Anthro Weekend",
+  "bluesky": {
+    "did": "did:plc:fwt566qqg3uhf36kswpmuqx2",
+    "handle": "mianthroweekend.bsky.social"
+  },
+  "events": [
+    {
+      "id": "michigan-anthro-weekend-2026",
+      "name": "Michigan Anthro Weekend 2026",
+      "url": "https://michigananthroweekend.com",
+      "startDate": "2026-10-01",
+      "endDate": "2026-10-04",
+      "venue": "Sheraton Grand Rapids Airport Hotel",
+      "address": "5700 28th Street SE, Grand Rapids, MI 49546, United States",
+      "locale": "en-US",
+      "latLng": [
+        42.9120128,
+        -85.5255885
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds Michigan Anthro Weekend, an 18+ furry convention run by Western Michigan Anthropomorphic Events, Inc. Inaugural year is 2026, four days in Grand Rapids.

Verified against the convention's own site rather than the issue text:

| Field | Value | Source |
| --- | --- | --- |
| Dates | 2026-10-01 → 2026-10-04 | Front page ("OCT 1—4 2026"), corroborated by the Bluesky bio |
| Venue | Sheraton Grand Rapids Airport Hotel | Hotel page |
| Address | 5700 28th Street SE, Grand Rapids, MI 49546, United States | Hotel page |
| Bluesky | `did:plc:fwt566qqg3uhf36kswpmuqx2` | Resolved from `@mianthroweekend.bsky.social` |

Two fields weren't in the submission and I filled them in: `latLng` (`42.9120128, -85.5255885`, an exact building match for the hotel), since 392 of 395 existing events carry coordinates, and a URL without a trailing slash to match every other record. Nothing in the repo already covers this convention.

## Verification

`tools/format.py` left the file byte-identical, so it's already canonical. `tools/materialize.py` emits both `series/michigan-anthro-weekend.json` and `events/michigan-anthro-weekend-2026.json`, and derives `timezone: "America/Detroit"` from the coordinates — an independent check that the latLng lands where it should.

## CI will be red, and not because of this change

`materialize.py` exits 1 on `main` as of da137e0:

```
ERROR:root:bewhiskered/bewhiskered-2026:$.id:not unique across all series, last seen in bewhiskered
```

`bewhiskered.json` lists `bewhiskered-2026` twice (ids in file order: 2026, 2027, 2026, 2025). I confirmed this reproduces on a clean tree with this PR's file removed, so `validate` will fail on any PR opened against `main` until the duplicate is resolved. Tracking separately.

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event details for Michigan Anthro Weekend 2026, including dates, venue, website, location, and Bluesky information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->