### PR TITLE
Remove duplicate Bewhiskered 2026 and placeholder 2027 entries

### DIFF
--- a/bewhiskered.json
+++ b/bewhiskered.json
@@ -20,34 +20,6 @@
       ]
     },
     {
-      "id": "bewhiskered-2027",
-      "name": "Bewhiskered 2027",
-      "url": "https://bewhiskeredcon.org",
-      "startDate": "2026-04-02",
-      "endDate": "2026-04-05",
-      "venue": "Coming Soon",
-      "address": "320 W 1550 N, Layton, UT 84041, USA",
-      "locale": "en-US",
-      "latLng": [
-        41.0829982,
-        -111.9720064
-      ]
-    },
-    {
-      "id": "bewhiskered-2026",
-      "name": "Bewhiskered 2026",
-      "url": "https://bewhiskeredcon.org",
-      "startDate": "2026-04-02",
-      "endDate": "2026-04-05",
-      "venue": "Durham Convention Center",
-      "address": "301 W Morgan St, Durham, NC 27701, United States",
-      "locale": "en-US",
-      "latLng": [
-        35.9975142,
-        -78.90234679999999
-      ]
-    },
-    {
       "id": "bewhiskered-2025",
       "name": "Bewhiskered 2025",
       "url": "https://bewhiskeredcon.org",


### PR DESCRIPTION
`validate` has been failing on `main` since da137e0:

```
ERROR:root:bewhiskered/bewhiskered-2026:$.id:not unique across all series, last seen in bewhiskered
```

That import_concat run prepended two events to `bewhiskered.json`. Both are bad.

## The duplicate

It added a second `bewhiskered-2026` alongside the one from fe47264. The two are byte-identical (compared as serialized dicts, not by eye), so there's nothing to reconcile — one of them just goes. This is what trips the cross-series unique-id check in `materialize.py` and what's been breaking `validate` on every PR opened since.

## The placeholder 2027

The same run also added `bewhiskered-2027`, assembled entirely from placeholder data:

| Field | Imported value | Reality |
| --- | --- | --- |
| `startDate` / `endDate` | `2026-04-02` / `2026-04-05` | the 2026 dates, copied verbatim |
| `venue` | `"Coming Soon"` | a placeholder string, not a venue |
| `address` | `320 W 1550 N, Layton, UT 84041, USA` | the con is in Durham, NC |

Every field is schema-valid, so `validate` never flagged it — it would have published to cons.fyi as a genuine listing: a Bewhiskered 2027 in Utah, on 2026 dates, at a venue called "Coming Soon".

`bewhiskeredcon.org` now 302s to `2027.bewhiskeredcon.org`, so a 2027 event is real, but that page says only *"Durham NC TBA 2027"* — no dates, no venue. Relabeling the duplicate 2026 to 2027 would move the fabrication rather than remove it, and the schema requires `startDate`/`endDate`/`venue`, so a dates-unknown entry can't be represented honestly. Dropping it; it gets re-added when dates are announced.

## Result

This restores `bewhiskered.json` to its exact pre-da137e0 contents — I diffed against `da137e0^:bewhiskered.json` and it matches byte for byte. 2026 and 2025 remain.

`tools/format.py` leaves the file unchanged, and `tools/materialize.py` now exits **0** across the whole repo, which unblocks #71 and any other open PR.

## This will regress in under six hours

`import_concat` runs on `cron: "15 */6 * * *"` and pushes straight to `main` — no `validate` step, since that workflow only triggers on `pull_request`. The next scheduled run will likely re-add both entries. The importer bug is filed separately; this PR clears the immediate breakage but is not the durable fix.
