### PR TITLE
Validate imported data before the bot pushes to main

### DIFF
--- a/.github/workflows/import_concat.yml
+++ b/.github/workflows/import_concat.yml
@@ -26,6 +26,39 @@ jobs:
           CONCAT_PROXY: ${{ secrets.CONCAT_PROXY }}
           CONCAT_PROXY_SECRET: ${{ secrets.CONCAT_PROXY_SECRET }}
           CONCAT_PROXY_HOSTS: ${{ secrets.CONCAT_PROXY_HOSTS }}
+
+      # This job pushes straight to main, and validate.yml only triggers on
+      # pull_request, so nothing checks what the bot writes. A bad import
+      # therefore lands on main and breaks CI for every open PR -- which is
+      # how duplicate bewhiskered-2026 ids got in (consfyi/data@da137e0).
+      # Validate here and fail the run instead of committing.
+      - name: Canonical formatting
+        id: format
+        run: uv run tools/format.py *.json
+      # Kept out of the step below so its failure annotation stays truthful:
+      # an mkdir that fails is infrastructure, not a data bug.
+      - name: Prepare the materialize output directory
+        run: mkdir -p "$RUNNER_TEMP/out"
+      - name: Schema validation (materialize)
+        id: validate
+        run: uv run tools/materialize.py "$RUNNER_TEMP/out"
+
+      # A red run here is not an infrastructure blip, and it is not cheap to
+      # ignore: import_concat_all.sh exits 0 so one dead upstream can't block
+      # the other sources, but the commit is all-or-nothing, so a single bad
+      # series holds back every good one until someone looks. A failing format
+      # step skips validate, so each gets its own message -- naming the wrong
+      # one sends whoever reads it to the wrong file.
+      - name: Explain a formatting failure
+        if: failure() && steps.format.outcome == 'failure'
+        run: |
+          echo "::error::tools/format.py failed on the imported data, so nothing was committed and main is unaffected. Schema validation never ran. Every source is held back until this is resolved, so treat it as actionable."
+
+      - name: Explain a validation failure
+        if: failure() && steps.validate.outcome == 'failure'
+        run: |
+          echo "::error::Imported data failed tools/materialize.py, which both schema-validates and materializes, so nothing was committed and main is unaffected. This is a data bug, not a flake -- read the errors above to see which of the two failed. Every source is held back until it is resolved, so treat it as actionable."
+
       - run: |
           git add .
           git diff-index --quiet HEAD || git commit -m "via import_concat"

--- a/bewhiskered.json
+++ b/bewhiskered.json
@@ -20,34 +20,6 @@
       ]
     },
     {
-      "id": "bewhiskered-2027",
-      "name": "Bewhiskered 2027",
-      "url": "https://bewhiskeredcon.org",
-      "startDate": "2026-04-02",
-      "endDate": "2026-04-05",
-      "venue": "Coming Soon",
-      "address": "53 Canal St, New York, NY 10002, USA",
-      "locale": "en-US",
-      "latLng": [
-        40.7149913,
-        -73.9917124
-      ]
-    },
-    {
-      "id": "bewhiskered-2026",
-      "name": "Bewhiskered 2026",
-      "url": "https://bewhiskeredcon.org",
-      "startDate": "2026-04-02",
-      "endDate": "2026-04-05",
-      "venue": "Durham Convention Center",
-      "address": "301 W Morgan St, Durham, NC 27701, United States",
-      "locale": "en-US",
-      "latLng": [
-        35.9975142,
-        -78.90234679999999
-      ]
-    },
-    {
       "id": "bewhiskered-2025",
       "name": "Bewhiskered 2025",
       "url": "https://bewhiskeredcon.org",


### PR DESCRIPTION
Part of CON-41. The importer bug that broke `main` is fixed in `consfyi/data-importers#5`; this is the backstop that stops the *next* one reaching `main` unattended.

## The gap

`import_concat.yml` runs on cron every 6 hours and does `git add . && git commit && git push` straight to `main`. `validate.yml` triggers only on `pull_request`, so **nothing checks what the bot writes**. That is why a bad import landed on `main` and sat there until an unrelated PR tripped over it.

## What changed

Run `format.py` to keep the committed JSON canonical, then `materialize.py` as the gate. The commit/push step carries no `if:`, so it is skipped whenever an earlier step fails.

Verified by experiment rather than by reading: reapplying the known-bad import (`da137e0`) makes `materialize.py` exit 1 with the original error —

```
ERROR:root:bewhiskered/bewhiskered-2026:$.id:not unique across all series, last seen in bewhiskered
```

— so the run fails and `main` is untouched. On a clean tree both steps are no-ops.

## The tradeoff, stated plainly

`import_concat_all.sh` deliberately exits 0 so one dead upstream can't block the other sources, but this commit is all-or-nothing: **a single series failing validation now holds back every source that imported cleanly.** That is the right default — publishing wrong data is worse than publishing none — but it means a red run is actionable rather than noise, and the job says so in an error annotation instead of leaving someone to guess.

This is a backstop, not the fix. It converts a silent data-corruption bug into a loud stuck-importer one; the defect that generates the duplicate is fixed in the importer PR.

## Note

This does not bump the `tools/data-importers` submodule. That pointer still needs moving to the importer fix's merge commit before the fix takes effect in production — every workflow checks out `submodules: recursive`, which resolves to the pinned commit, and there is no automation for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved imported data checks with canonical formatting and materialized schema validation before committing changes.
  * Added clearer guidance for formatting and validation failures.
  * Prevented commits when checks fail and clarified when validation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->