### PR TITLE
Fix Nord-Furs Silvester 2025 end date

### DIFF
--- a/nord-furs-silvester.json
+++ b/nord-furs-silvester.json
@@ -6,7 +6,7 @@
       "name": "Nord-Furs Silvester 2025",
       "url": "https://app.hi.events/event/3379/nord-furs-silvester",
       "startDate": "2025-12-30",
-      "endDate": "2025-12-01",
+      "endDate": "2026-01-01",
       "venue": "DJH Jugendherberge Müden/Örtze",
       "address": "Wiesenweg 32, 29328 Faßberg, Deutschland",
       "locale": "de-DE",


### PR DESCRIPTION
`nord-furs-silvester-2025` had `endDate` **2025-12-01**, which is 29 days *before* its `startDate` of 2025-12-30. The year was mistyped.

The event runs **30.12.2025 – 01.01.2026**, confirmed on its [hi.events ticketing page](https://app.hi.events/event/3379/nord-furs-silvester) ("Tue, Dec 30, 2025 3:00 PM - Thu, Jan 1, 2026 10:00 AM GMT+1") and in the organizers' own announcements. So `endDate` becomes 2026-01-01.

### No test, and why

The check that would have caught this already exists in `tools/schema.json` but never runs:

```json
"endDate": { "type": "string", "format": "date",
             "formatMinimum": { "$data": "1/startDate" } }
```

`formatMinimum` and `$data` are Ajv (JavaScript) extensions. `tools/materialize.py` validates with Python `jsonschema.Draft202012Validator`, which ignores unknown keywords silently — so this constraint has never been enforced, which is how the bad row survived in `main`. Filed separately rather than bundled here to keep this diff to the data fix.

### CI note

`validate` will fail on this PR with `bewhiskered/bewhiskered-2026:$.id:not unique across all series`. That is pre-existing breakage on `main` (CON-41), unrelated to this change. Locally, `materialize.py` reports only that error and nothing about nord-furs.