### PR TITLE
Point Aberacon, Furcation and Furski at their official Bluesky accounts

### DIFF
--- a/aberacon.json
+++ b/aberacon.json
@@ -1,8 +1,8 @@
 {
   "name": "Aberacon",
   "bluesky": {
-    "did": "did:plc:fxqamrjizs6dhp7vwgskble5",
-    "handle": "skydreampegasus.bsky.social"
+    "did": "did:plc:5pu5fklli4wad6pq2mgotnph",
+    "handle": "aberacon.wales"
   },
   "events": [
     {

--- a/furcation.json
+++ b/furcation.json
@@ -1,8 +1,8 @@
 {
   "name": "Furcation",
   "bluesky": {
-    "did": "did:plc:clgiak22ikoxswjcxn6prgw7",
-    "handle": "furcationland.org"
+    "did": "did:plc:2rw4e5md25htk64onqqaqpsk",
+    "handle": "furcation.org.uk"
   },
   "events": [
     {

--- a/furski.json
+++ b/furski.json
@@ -1,8 +1,8 @@
 {
   "name": "Furski",
   "bluesky": {
-    "did": "did:plc:v35sycvmrnj7uu6wnhi3z3vj",
-    "handle": "techno.fur.ski"
+    "did": "did:plc:lr3kagqvxx4dluizlgso3oyx",
+    "handle": "fur.ski"
   },
   "events": [
     {


### PR DESCRIPTION
Three series were pointing `bluesky` at an account that is not the convention's own, so key-date extraction has been reading the wrong timeline for each of them.

This came out of an audit prompted by #69, which found the same problem on Texas Furry Fiesta. That one is already fixed; these are the rest.

## What was wrong

| Series | Was | Now | Why it was wrong |
|---|---|---|---|
| `aberacon` | `skydreampegasus.bsky.social` | `aberacon.wales` | Personal account. The bio describes a person and self-identifies as a "convention staffer". |
| `furcation` | `furcationland.org` | `furcation.org.uk` | A different convention's account. Furcationland is a US con in Portland, ME; this file is the UK Furcation at Burnham-on-Sea. The DID was shared with `furcationland.json`, where it is correct and stays. |
| `furski` | `techno.fur.ski` | `fur.ski` | Personal account of a staffer, hosted on the convention's own domain, so the domain handle did not imply an official account. |

## Verification

Each replacement DID was resolved against the public Bluesky API, and the live handle matches the handle recorded beside it. `furcationland.json` and `texas-furry-fiesta.json` were re-checked too and are correct as-is.

Both CI steps were run locally before pushing: `tools/format.py` produced no changes beyond the six edited lines, and `tools/materialize.py` exits 0.

## Impact

No incorrect data shipped. Every published `keyDates` source URI in the dataset resolves to the account stored in its own file, and none of these three series had any `keyDates` yet. The effect was missed extraction rather than wrong extraction. Aberacon 2026 is the time-sensitive one, running 28–30 August.

## Not addressed here

Nothing in the schema can catch this: a wrong DID is structurally valid. A duplicate-DID check would have caught the Furcation case, but it needs an allowlist, since there are three legitimate shared DIDs in the dataset (`east`/`sachsen-fur-dance`, `furconz-camp`/`furconz-hotel`, `furry-down-under`/`tails-of-terror`). Deciding that allowlist is a separate change.

The other two would have defeated a duplicate check regardless. Worth noting for anyone building a guard later: the Aberacon account carried the convention's name in its display name, and the Furski account was on the convention's own domain, so both pass the obvious heuristics. Reading profile bios is what found them.

Separately, 13 series have upcoming events and no `bluesky` block at all, so they sit outside key-date extraction entirely. Also out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Aberacon’s Bluesky identity information.
  - Updated Furcation’s Bluesky DID and handle to reflect its current identity.
  - Updated Furski’s Bluesky handle from `techno.fur.ski` to `fur.ski`.
  - These changes ensure Bluesky profile links and identity references resolve to the correct accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->