### PR TITLE
Key dates from Bluesky

### DIFF
--- a/midwest-furfest.json
+++ b/midwest-furfest.json
@@ -17,7 +17,31 @@
       "latLng": [
         41.9792232,
         -87.861987
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-08-20",
+            "source": "https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcla3o6hc2m",
+            "asOf": "2026-08-17T20:48:49.687Z",
+            "confidence": 1
+          }
+        },
+        "dealers": {
+          "opens": {
+            "date": "2026-08-20",
+            "source": "https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcollzs3s2m",
+            "asOf": "2026-08-17T21:48:57.172Z",
+            "confidence": 1
+          },
+          "closes": {
+            "date": "2026-08-29",
+            "source": "https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcollzs3s2m",
+            "asOf": "2026-08-17T21:48:57.172Z",
+            "confidence": 1
+          }
+        }
+      }
     },
     {
       "id": "midwest-furfest-2025",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-oss-20b` · Verify (unanimous): `openai/gpt-oss-120b` + `openai/gpt-oss-20b` · 2026-08-17_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**midwest-furfest.json** — `midwest-furfest-2026` dealers.opens → **2026-08-20** (add, conf 1)
> DEALERS: Our Dealers Den applications will be opening August 20th at 7pm CDT! Applications will close August 29th at 11:59 pm CDT Check out our Dealers information page below, and get ready to rock ✨ ow.ly/jpjY50ZAHuX
> — [source post](https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcollzs3s2m) at 2026-08-17T21:48:57.172Z

**midwest-furfest.json** — `midwest-furfest-2026` dealers.closes → **2026-08-29** (add, conf 1)
> DEALERS: Our Dealers Den applications will be opening August 20th at 7pm CDT! Applications will close August 29th at 11:59 pm CDT Check out our Dealers information page below, and get ready to rock ✨ ow.ly/jpjY50ZAHuX
> — [source post](https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcollzs3s2m) at 2026-08-17T21:48:57.172Z

**midwest-furfest.json** — `midwest-furfest-2026` registration.opens → **2026-08-20** (add, conf 1)
> It's (almost) time~ Registration for Midwest FurFest opens August 20, 2026! Learn more about registering for our convention here: www.furfest.org/attend/regis...
> — [source post](https://bsky.app/profile/did:plc:uwoi7anxjcden4hkzck6h6c7/post/3mtcla3o6hc2m) at 2026-08-17T20:48:49.687Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 2026 registration and dealer key dates for Midwest FurFest, including opening and closing dates.
  * Included source links, timestamps, and confidence details for the newly added event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->