### PR TITLE
Add Las Vegas Howlfest 2027

### DIFF
--- a/las-vegas-howlfest.json
+++ b/las-vegas-howlfest.json
@@ -1,0 +1,27 @@
+{
+  "name": "Las Vegas Howlfest",
+  "bluesky": {
+    "did": "did:plc:yo37kvl6sz4azmbx2bnmvjed",
+    "handle": "howlfest.vegas"
+  },
+  "events": [
+    {
+      "id": "las-vegas-howlfest-2027",
+      "name": "Las Vegas Howlfest 2027",
+      "url": "https://howlfest.vegas",
+      "startDate": "2027-10-21",
+      "endDate": "2027-10-24",
+      "venue": "Alexis Park Resort and Serene Boutique",
+      "address": "375 E Harmon Ave, Las Vegas, NV 89169, United States",
+      "locale": "en-US",
+      "latLng": [
+        36.1075771,
+        -115.1562516
+      ],
+      "sources": [
+        "https://howlfest.vegas",
+        "https://t.me/LVHowlfest"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New series from the LVFC team: Las Vegas Howlfest, Oct 21-24 2027 at the Alexis Park (21+). Announced on the LVFC Telegram; site is https://howlfest.vegas, Telegram https://t.me/LVHowlfest.

Venue/address/coordinates match the existing LVFC record. Bluesky account howlfest.vegas is linked from the site and resolved to its DID.

`tools/format.py` is a no-op on the file and `tools/materialize.py` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an event listing for Las Vegas Howlfest 2027.
  * Included event dates, venue details, location, coordinates, locale, and source links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->