### PR TITLE
Key dates from Bluesky

### DIFF
--- a/las-vegas-howlfest.json
+++ b/las-vegas-howlfest.json
@@ -21,7 +21,17 @@
       "sources": [
         "https://howlfest.vegas",
         "https://t.me/LVHowlfest"
-      ]
+      ],
+      "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-08-17",
+            "source": "https://bsky.app/profile/did:plc:yo37kvl6sz4azmbx2bnmvjed/post/3mtcphwxoc224",
+            "asOf": "2026-08-17T22:04:48.160Z",
+            "confidence": 0.9
+          }
+        }
+      }
     }
   ]
 }

--- a/tails-and-tornadoes-fur-con.json
+++ b/tails-and-tornadoes-fur-con.json
@@ -69,6 +69,12 @@
             "source": "https://bsky.app/profile/tailsandtornadoes.org/post/3mlh4t5lnh223",
             "asOf": "2026-05-09T20:52:47.536Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-08-15",
+            "source": "https://bsky.app/profile/did:plc:dum5xzdrx7qkj3jtlrc3yaje/post/3msoq76iksg26",
+            "asOf": "2026-08-09T23:24:33.018Z",
+            "confidence": 1.0
           }
         },
         "djs": {


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-oss-20b` · Verify (unanimous): `openai/gpt-oss-120b` + `openai/gpt-oss-20b` · 2026-08-18_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**las-vegas-howlfest.json** — `las-vegas-howlfest-2027` registration.opens → **2026-08-17** (add, conf 0.9)
> The duality of furries (Reg is open by the way!)
> — [source post](https://bsky.app/profile/did:plc:yo37kvl6sz4azmbx2bnmvjed/post/3mtcphwxoc224) at 2026-08-17T22:04:48.160Z

**tails-and-tornadoes-fur-con.json** — `tails-and-tornadoes-fur-con-2026` performances.closes → **2026-08-15** (add, conf 1.0)
> !!LAST CALL!! The TTFC Dance Competition is just around the corner, and the stage is waiting for YOU! Applications close Saturday, August 15 at midnight! Don’t miss your chance to take the stage, turn up the music, and shake your tail! #TTFC2026 tailsandtornadoes.org/dance-comp
> — [source post](https://bsky.app/profile/did:plc:dum5xzdrx7qkj3jtlrc3yaje/post/3msoq76iksg26) at 2026-08-09T23:24:33.018Z