### PR TITLE
Key dates from Bluesky

### DIFF
--- a/further-confusion.json
+++ b/further-confusion.json
@@ -19,6 +19,14 @@
         -121.889011
       ],
       "keyDates": {
+        "registration": {
+          "opens": {
+            "date": "2026-08-18",
+            "source": "https://bsky.app/profile/did:plc:fj45oznjbvlgoyzjqi6tlt3n/post/3mtf7xuft5d24",
+            "asOf": "2026-08-18T22:05:21.675Z",
+            "confidence": 1
+          }
+        },
         "dealers": {
           "opens": {
             "date": "2026-06-09",


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-oss-20b` · Verify (unanimous): `openai/gpt-oss-120b` + `openai/gpt-oss-20b` · 2026-08-19_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**further-confusion.json** — `further-confusion-2027` registration.opens → **2026-08-18** (add, conf 1)
> Now that we are back from the beach and all dried up, its time to prepare for all the fun that lays ahead... Registration for Further Confusion 2027 is now open! It's going to be a wild ride. Register here: furtherconfusion.org/register/
> — [source post](https://bsky.app/profile/did:plc:fj45oznjbvlgoyzjqi6tlt3n/post/3mtf7xuft5d24) at 2026-08-18T22:05:21.675Z