### PR TITLE
Clarify that keyDates asOf is the source post's createdAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ interface Event {
   ///
   /// Each deadline records the `date` (ISO 8601 yyyy-MM-dd), the `source` URI of
   /// the announcement post it was extracted from, the `asOf` timestamp (ISO 8601
-  /// date-time) of when the source was observed, and a `confidence` between 0
-  /// and 1.
+  /// date-time) of the source post itself (its `createdAt`, not when it was
+  /// indexed or observed), and a `confidence` between 0 and 1.
   keyDates?: {
     registration?: KeyDate;
     hotel?: KeyDate;


### PR DESCRIPTION
The README described `asOf` as the time the source was observed. The worker records the post's own `createdAt`, and every existing entry follows that, so the wording now says so. Docs-only, no data or code change.

Prompted by CodeRabbit's comment on #86.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `asOf` refers to the source post’s creation timestamp, rather than when it was observed or indexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->