### PR TITLE
Key dates from Bluesky

### DIFF
--- a/carolina-furfare.json
+++ b/carolina-furfare.json
@@ -63,6 +63,14 @@
             "confidence": 0.9
           }
         },
+        "performances": {
+          "opens": {
+            "date": "2026-08-03",
+            "source": "https://bsky.app/profile/did:plc:eamjvw2tcnvapbkjhbwyuiy7/post/3ms7o56q5vs2b",
+            "asOf": "2026-08-03T23:37:42.618Z",
+            "confidence": 1.0
+          }
+        },
         "djs": {
           "opens": {
             "date": "2026-05-14",

--- a/heartland-howloween.json
+++ b/heartland-howloween.json
@@ -29,6 +29,14 @@
             "asOf": "2026-07-01T15:29:54.249Z",
             "confidence": 0.95
           }
+        },
+        "panels": {
+          "closes": {
+            "date": "2026-08-21",
+            "source": "https://bsky.app/profile/did:plc:mtchwur7zw7mnusl7vuyi76f/post/3msissimgdk2u",
+            "asOf": "2026-08-07T14:55:10.237Z",
+            "confidence": 0.9
+          }
         }
       }
     },

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -72,6 +72,12 @@
             "source": "https://bsky.app/profile/stratosfur.org/post/3mletld5ecc25",
             "asOf": "2026-05-08T23:02:02.799166Z",
             "confidence": 0.9
+          },
+          "closes": {
+            "date": "2026-08-21",
+            "source": "https://bsky.app/profile/did:plc:a2gt2pfvvoovijq4uc2ivije/post/3msqmvcepbp2u",
+            "asOf": "2026-08-10T17:30:39.628231Z",
+            "confidence": 0.9
           }
         },
         "djs": {


### PR DESCRIPTION
## Key dates from Bluesky

_Extract: `openai/gpt-oss-20b` · Verify (unanimous): `openai/gpt-oss-120b` + `openai/gpt-oss-20b` · 2026-08-19_

### Applied (unanimously verified — `/reject <event> <category>.<kind>` to drop a bad entry for good)

**stratosfur.json** — `stratosfur-2026` performances.closes → **2026-08-21** (add, conf 0.9)
> StratosFur is almost here, and dance comp sign-ups are STILL open! Whether you’re just starting out or a dance comp veteran, this is your moment to jump in and show what you’ve got. Applications will close August 21st at 11:59pm
> — [source post](https://bsky.app/profile/did:plc:a2gt2pfvvoovijq4uc2ivije/post/3msqmvcepbp2u) at 2026-08-10T17:30:39.628231Z

**heartland-howloween.json** — `heartland-howloween-2026` panels.closes → **2026-08-21** (add, conf 0.9)
> HHFC is approaching quickly! That means Panel Applications are: CLOSING SOON! If you have an idea to talk about, time is ticking! August 21st is the final day to submit an application. Applicants will receive an email about acceptances or waitlisted panels on August 28th.
> — [source post](https://bsky.app/profile/did:plc:mtchwur7zw7mnusl7vuyi76f/post/3msissimgdk2u) at 2026-08-07T14:55:10.237Z

**carolina-furfare.json** — `carolina-furfare-2026` performances.opens → **2026-08-03** (add, conf 1.0)
> To all you creepishly cool cryptids out there, the has come to put your lip-sync skills to the test! Don't worry, we won't judge you..MUCH. 😈 Sign up for LipSync Battles today! forms.gle/6sNbJpCgXhTE...
> — [source post](https://bsky.app/profile/did:plc:eamjvw2tcnvapbkjhbwyuiy7/post/3ms7o56q5vs2b) at 2026-08-03T23:37:42.618Z

### Refuted by verification (not applied)
- `stratosfur-2026` registration.closes 2026-08-12 — Post mentions a price increase on Aug 13 and a pre‑registration deadline, not a hard closing of registration sales.
- `stratosfur-2026` hotel.closes 2026-08-13 — Post states the last day to book a room is August 12, 2026, conflicting with the claimed hotel close of August 13, 2026.
- `stratosfur-2026` panels.opens 2026-07-08 — Post says panel submissions are open but does not explicitly give an opening date; the claim’s date is not stated in the text.
- `stratosfur-2026` volunteers.opens 2026-05-20 — Post invites volunteers to apply but does not explicitly mention an opening date; the claim’s May 20 date is not stated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Information**
  * Added the 2026 panel application deadline for Heartland Howloween: August 21, 2026.
  * Added the 2026 performance opening date for Carolina FurFare: August 3, 2026.
  * Added the 2026 performance closing date for StratosFur: August 21, 2026.
* **Data Updates**
  * Included source references, verification timestamps, and confidence information for the newly added event dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->