### PR TITLE
Shift 17 keyDates entries recorded in UTC to the venue's local date [CON-50]

### DIFF
--- a/anthro-weekend-utah.json
+++ b/anthro-weekend-utah.json
@@ -57,7 +57,7 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-03-17",
+            "date": "2026-03-16",
             "source": "https://bsky.app/profile/anthroweekendutah.org/post/3mh7v4yruss2t",
             "asOf": "2026-03-17T02:05:44.665Z",
             "confidence": 0.95

--- a/brasil-furfest.json
+++ b/brasil-furfest.json
@@ -21,7 +21,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2025-09-22",
+            "date": "2025-09-21",
             "source": "https://bsky.app/profile/brasilfurfest.bsky.social/post/3lzfes2lcck2e",
             "asOf": "2025-09-22T02:36:33.216Z",
             "confidence": 0.9

--- a/canfurence.json
+++ b/canfurence.json
@@ -49,7 +49,7 @@
             "confidence": 0.95
           },
           "closes": {
-            "date": "2026-05-16",
+            "date": "2026-05-15",
             "source": "https://bsky.app/profile/canfurence.bsky.social/post/3mlwraxur6c2r",
             "asOf": "2026-05-16T02:08:23.462Z",
             "confidence": 1

--- a/capital-fur-con.json
+++ b/capital-fur-con.json
@@ -40,7 +40,7 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-07-07",
+            "date": "2026-07-06",
             "source": "https://bsky.app/profile/capitalfurcon.org/post/3mpzehwz2wc2c",
             "asOf": "2026-07-07T00:38:24.515Z",
             "confidence": 0.85

--- a/confuror.json
+++ b/confuror.json
@@ -24,7 +24,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-04-02",
+            "date": "2026-04-01",
             "source": "https://bsky.app/profile/confuror.bsky.social/post/3mii4bqyycs22",
             "asOf": "2026-04-02T02:00:10.006Z",
             "confidence": 0.85

--- a/fur-eh.json
+++ b/fur-eh.json
@@ -51,7 +51,7 @@
         },
         "performances": {
           "opens": {
-            "date": "2026-07-10",
+            "date": "2026-07-09",
             "source": "https://bsky.app/profile/fur-eh.bsky.social/post/3mqbb5nnmct2n",
             "asOf": "2026-07-10T04:00:15.389618096Z",
             "confidence": 0.9

--- a/furrest-city.json
+++ b/furrest-city.json
@@ -54,7 +54,7 @@
         },
         "performances": {
           "opens": {
-            "date": "2026-06-19",
+            "date": "2026-06-18",
             "source": "https://bsky.app/profile/furrestcity.org/post/3mom6rfbzls2w",
             "asOf": "2026-06-19T01:26:30.796Z",
             "confidence": 0.9

--- a/further-confusion.json
+++ b/further-confusion.json
@@ -29,7 +29,7 @@
         },
         "dealers": {
           "opens": {
-            "date": "2026-06-09",
+            "date": "2026-06-08",
             "source": "https://bsky.app/profile/furcon.bsky.social/post/3mntme2y4rt26",
             "asOf": "2026-06-09T06:53:02.693Z",
             "confidence": 0.95

--- a/gateway-furmeet.json
+++ b/gateway-furmeet.json
@@ -65,7 +65,7 @@
         },
         "performances": {
           "opens": {
-            "date": "2026-05-14",
+            "date": "2026-05-13",
             "source": "https://bsky.app/profile/gatewayfurmeet.org/post/3mlrj6phvch2h",
             "asOf": "2026-05-14T00:00:38.875376+00:00",
             "confidence": 0.85

--- a/mephit-fur-meet.json
+++ b/mephit-fur-meet.json
@@ -32,7 +32,7 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-04-16",
+            "date": "2026-04-15",
             "source": "https://bsky.app/profile/mephitfurmeet.org/post/3mjlbed636c2f",
             "asOf": "2026-04-16T01:34:15.718Z",
             "confidence": 0.9

--- a/noctfurnal.json
+++ b/noctfurnal.json
@@ -24,7 +24,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-07-11",
+            "date": "2026-07-10",
             "source": "https://bsky.app/profile/noctfurnalevents.bsky.social/post/3mqdm35nm222e",
             "asOf": "2026-07-11T02:21:02.564Z",
             "confidence": 0.9

--- a/pawcon.json
+++ b/pawcon.json
@@ -29,7 +29,7 @@
         },
         "hotel": {
           "opens": {
-            "date": "2026-02-19",
+            "date": "2026-02-18",
             "source": "https://bsky.app/profile/pawcon.bsky.social/post/3mf6h2s3axk2v",
             "asOf": "2026-02-19T01:30:55.150Z",
             "confidence": 0.9

--- a/pawstral.json
+++ b/pawstral.json
@@ -24,7 +24,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-04-04",
+            "date": "2026-04-03",
             "source": "https://bsky.app/profile/pawstral.bsky.social/post/3min4ym5c4c2o",
             "asOf": "2026-04-04T01:56:15.355Z",
             "confidence": 0.85
@@ -40,7 +40,7 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-05-18",
+            "date": "2026-05-17",
             "source": "https://bsky.app/profile/pawstral.bsky.social/post/3mm3t3tgpwk2x",
             "asOf": "2026-05-18T02:24:37.203Z",
             "confidence": 0.82

--- a/stratosfur.json
+++ b/stratosfur.json
@@ -24,7 +24,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-02-11",
+            "date": "2026-02-10",
             "source": "https://bsky.app/profile/stratosfur.org/post/3mekeykdc5s2l",
             "asOf": "2026-02-11T02:00:37.458947Z",
             "confidence": 0.95
@@ -54,7 +54,7 @@
         },
         "panels": {
           "opens": {
-            "date": "2026-03-14",
+            "date": "2026-03-13",
             "source": "https://bsky.app/profile/stratosfur.org/post/3mgy5avem7v2v",
             "asOf": "2026-03-14T00:09:47.136058Z",
             "confidence": 0.85

--- a/western-pa-furry-weekend.json
+++ b/western-pa-furry-weekend.json
@@ -24,7 +24,7 @@
       "keyDates": {
         "registration": {
           "opens": {
-            "date": "2026-06-06",
+            "date": "2026-06-05",
             "source": "https://bsky.app/profile/wpafw.bsky.social/post/3mnlk3u5bek2h",
             "asOf": "2026-06-06T01:51:21.714Z",
             "confidence": 0.95


### PR DESCRIPTION
Step 3 of CON-50 (https://linear.app/consfyi/issue/CON-50). The worker fix is consfyi/bsky-event-ingester#35.

## Why

The keydates worker resolved "today"/"now open" against the raw UTC `createdAt`, so a same-day announcement posted in the venue's evening got stamped one day late. #35 fixes the worker; this PR corrects the entries the bug already produced.

## Method

Swept every `keyDates` entry whose stored `date` equals the UTC date of `asOf` while the venue-local date (tzfpy on the event's `latLng`, the same lookup `tools/materialize.py` uses) differs. 20 matched; each source post was then read.

- **17 corrected here** — the post announces a same-day open/close with no explicit date, so the honest date is the local one, one day earlier.
- **tails-and-tornadoes-fur-con-2026 panels.closes** — kept; the post names "tomorrow, July 1" explicitly.
- **pawai-2026 registration.closes** — kept; east-of-UTC mirror case, the stored June 30 is the local close.
- **carolina-furfare-2026 hotel.opens** — kept; the post never states an opening, a weak extraction rather than a timezone error (not this issue's scope).

`asOf` and `source` are unchanged; only `date` moves. `tools/format.py` and `tools/materialize.py` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Corrected registration opening dates for Anthro Weekend Utah, Brasil FurFest, Confuror, Noctfurnal, Western PA Furry Weekend, and other 2026 events.
  * Updated panel registration dates for Anthro Weekend Utah, Mephit Fur Meet, Pawstral, and StratosFur.
  * Corrected CanFURence’s 2026 panel closing date.
  * Updated dealer registration dates for Capital Fur Con 2027 and Further Confusion 2027.
  * Updated performances registration dates for Fur-Eh!, Furrest City, and Gateway FurMeet.
  * Corrected PawCon’s 2026 hotel registration opening date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->